### PR TITLE
Seperate classification level tables

### DIFF
--- a/index.py
+++ b/index.py
@@ -19,7 +19,7 @@ datasets = {
 
 
 def run():
-    st.beta_set_page_config(page_title="Data Engineering QAQC", page_icon="📊")
+    st.set_page_config(page_title="Data Engineering QAQC", page_icon="📊")
     st.sidebar.markdown(
         """
         <div stule="margin-left: auto; margin-right: auto;">

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         "psycopg2-binary",
         "pandas<1.1",
         "numpy",
-        "streamlit==0.66.0",
+        "streamlit==1.8.1",
         "plotly",
     ],
     zip_safe=False,


### PR DESCRIPTION
## Change layout of facDB page

This PR is to address [this issue](https://github.com/NYCPlanning/data-engineering-qaqc/issues/8) that I can't link for some reason. I also can't add Max or Te as reviewers or tag them. 

 The reason I made this change is that there is dropdown on the left sidebar for selecting a classification level. This dropdown dynamically changes 4 out of 12 charts/tables on the page. I think this is bad design, it's hard to tell what info on the screen is based on the category you chose. It's better for all tables that change based on classification level to be next to each together.

The way it works in this PR is that first the user chooses whether they want to do a "general review" or "review by classification level". General review brings up the 8 tables that are unaffected by classification level, and review by classification table brings up the other 4 as well as the dropdown to select a classification level. The content itself doesn't change, just when it's presented.

I think you should both open this version of the app on your machines and see if it's more clear. I have no clue which of these tables will end up being useful, the point here is to focus less on the content of facDB data and more on how we want to collaboratively work on the app.