### PR TITLE
PLUTO gets tables from Digital Ocean instead of publishing database

### DIFF
--- a/index.py
+++ b/index.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from src.pluto import pluto
+from src.pluto.pluto import pluto
 from src.ztl import ztl
 from src.facdb.facdb import facdb
 from src.devdb import devdb
@@ -38,7 +38,7 @@ def run():
             datasets_list,
             index=datasets_list.index(query_params["page"][0]),
         )
-    else: 
+    else:
         name = "Home"
 
     if name:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "numpy",
         "streamlit",
         "plotly",
+        "python-dotenv"
     ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
         "numpy",
         "streamlit",
         "plotly",
-        "python-dotenv"
+        "python-dotenv",
+        "json"
     ],
     zip_safe=False,
 )

--- a/src/pluto.py
+++ b/src/pluto.py
@@ -7,6 +7,7 @@ def pluto():
     import os
     from datetime import datetime
     import requests
+    import boto3
 
     ENGINE = os.environ["ENGINE"]
 
@@ -17,6 +18,22 @@ def pluto():
     """
     )
 
+    def get_branches():
+        branches=set()
+        resource = boto3.resource(
+            "s3",
+            aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"],
+            endpoint_url = os.environ["AWS_S3_ENDPOINT"]
+        )
+        pub_bucket= resource.Bucket('edm-publishing')
+        for obj in pub_bucket.objects.filter(Prefix='db-pluto/'):
+            dir_name = obj._key.split('/')[1]
+            if not dir_name.isnumeric(): #When I come back on monday: filter out dates
+                branches.add(dir_name)
+        return branches
+    branches = get_branches()
+    print(branches)
     engine = create_engine(ENGINE)
 
     @st.cache(suppress_st_warning=True, allow_output_mutation=True)

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -15,20 +15,22 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/output/qaqc"
     rv["df_mismatch"] = csv_from_DO(f"{url}/qaqc_mismatch.csv")
     rv["df_null"] = csv_from_DO(f"{url}/qaqc_null.csv")
-    rv["df_aggregate"] =csv_from_DO(f"{url}/qaqc_aggregate.csv")
+    rv["df_aggregate"] = csv_from_DO(f"{url}/qaqc_aggregate.csv")
     df_expected = csv_from_DO(f"{url}/qaqc_expected.csv")
-    df_expected['expected'] = df_expected['expected'].apply(json.loads)
+    df_expected["expected"] = df_expected["expected"].apply(json.loads)
     rv["df_expected"] = df_expected
-    
+
     source_data_versions = pd.read_csv(
         f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/output/source_data_versions.csv"
     )
-    rv['source_data_version'] = source_data_versions
+    rv["source_data_version"] = source_data_versions
     sdv = source_data_versions.to_dict("records")
     version = {}
     for i in sdv:
         version[i["schema_name"]] = i["v"]
-    rv['version_text'] = f"""
+    rv[
+        "version_text"
+    ] = f"""
         Department of City Planning – E-Designations: ***{convert(version['dcp_edesignation'])}***  
         Department of City Planning – Georeferenced NYC Zoning Maps: ***{convert(version['dcp_zoningmapindex'])}***  
         Department of City Planning – NYC City Owned and Leased Properties: ***{convert(version['dcp_colp'])}***  
@@ -79,5 +81,6 @@ def blacklist_branches(branches):
             rv.append(b)
     return rv
 
+
 def csv_from_DO(url):
-    return pd.read_csv(url, true_values=['t'], false_values=['f'])
+    return pd.read_csv(url, true_values=["t"], false_values=["f"])

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -2,6 +2,7 @@ import boto3
 import re
 import pandas as pd
 from datetime import datetime
+import json
 from typing import Dict
 import os
 from dotenv import load_dotenv
@@ -15,7 +16,10 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
     rv["df_mismatch"] = csv_from_DO(f"{url}/qaqc_mismatch.csv")
     rv["df_null"] = csv_from_DO(f"{url}/qaqc_null.csv")
     rv["df_aggregate"] =csv_from_DO(f"{url}/qaqc_aggregate.csv")
-    rv["df_expected"] = csv_from_DO(f"{url}/qaqc_expected.csv")
+    df_expected = csv_from_DO(f"{url}/qaqc_expected.csv")
+    df_expected['expected'] = df_expected['expected'].apply(json.loads)
+    rv["df_expected"] = df_expected
+    
     source_data_versions = pd.read_csv(
         f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/output/source_data_versions.csv"
     )

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -1,0 +1,79 @@
+import boto3
+import re
+import pandas as pd
+from datetime import datetime
+from typing import Dict
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_data(branch) -> Dict[str, pd.DataFrame]:
+    rv = {}
+    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/output/qaqc"
+    rv["df_mismatch"] = csv_from_DO(f"{url}/qaqc_mismatch.csv")
+    rv["df_null"] = csv_from_DO(f"{url}/qaqc_null.csv")
+    rv["df_aggregate"] =csv_from_DO(f"{url}/qaqc_aggregate.csv")
+    rv["df_expected"] = csv_from_DO(f"{url}/qaqc_expected.csv")
+    source_data_versions = pd.read_csv(
+        f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/output/source_data_versions.csv"
+    )
+    rv['source_data_version'] = source_data_versions
+    sdv = source_data_versions.to_dict("records")
+    version = {}
+    for i in sdv:
+        version[i["schema_name"]] = i["v"]
+    rv['version_text'] = f"""
+        Department of City Planning – E-Designations: ***{convert(version['dcp_edesignation'])}***  
+        Department of City Planning – Georeferenced NYC Zoning Maps: ***{convert(version['dcp_zoningmapindex'])}***  
+        Department of City Planning – NYC City Owned and Leased Properties: ***{convert(version['dcp_colp'])}***  
+        Department of City Planning – NYC GIS Zoning Features: ***{convert(version['dcp_zoningdistricts'])}***  
+        Department of City Planning – Political and Administrative Districts: ***{convert(version['dcp_cdboundaries_wi'])}***  
+        Department of City Planning – Geosupport version: ***{convert(version['dcp_cdboundaries_wi'])}***  
+        Department of Finance – Digital Tax Map (DTM): ***{convert(version['dof_dtm'])}***  
+        Department of Finance – Mass Appraisal System (CAMA): ***{convert(version['pluto_input_cama_dof'])}***  
+        Department of Finance – Property Tax System (PTS): ***{convert(version['pluto_pts'])}***  
+        Landmarks Preservation Commission – Historic Districts: ***{convert(version['lpc_historic_districts'])}***  
+        Landmarks Preservation Commission – Individual Landmarks: ***{convert(version['lpc_landmarks'])}***  
+    """
+
+    return rv
+
+
+def get_branches():
+    all_branches = set()
+    resource = boto3.resource(
+        "s3",
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+        endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
+    )
+    pub_bucket = resource.Bucket("edm-publishing")
+    for obj in pub_bucket.objects.filter(Prefix="db-pluto/"):
+        all_branches.add(obj._key.split("/")[1])
+    rv = blacklist_branches(all_branches)
+    return rv
+
+
+def convert(dt):
+    try:
+        d = datetime.strptime(dt, "%Y/%m/%d")
+        return d.strftime("%m/%d/%y")
+    except BaseException:
+        return dt
+
+
+def blacklist_branches(branches):
+    """For pluto this is done by programmatically, can also be hard-coded"""
+    rv = []
+    for b in branches:
+        if (
+            re.match(r"[0-9]{2}v[0-9]", b) is None
+            and re.match(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", b) is None
+        ):
+            rv.append(b)
+    return rv
+
+def csv_from_DO(url):
+    return pd.read_csv(url, true_values=['t'], false_values=['f'])

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -9,15 +9,12 @@ def pluto():
     import requests
     from src.pluto.helpers import get_branches, get_data
 
-
     st.title("PLUTO QAQC")
     st.markdown(
         """
     ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/NYCPlanning/db-pluto?label=version) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NYCPlanning/db-pluto/CI?label=CI) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NYCPlanning/db-pluto/CAMA%20Processing?label=CAMA) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NYCPlanning/db-pluto/PTS%20processing?label=PTS)
     """
     )
-
-
 
     branches = get_branches()
     branch = st.sidebar.selectbox(
@@ -43,7 +40,8 @@ def pluto():
         "21v2",
         "21v3",
         "21v4",
-        "22v1"]
+        "22v1",
+    ]
 
     versions_order = [
         "19v1",
@@ -261,8 +259,6 @@ def pluto():
             :,
         ]
 
-        print(f'v1={v1}, v2={v2},')
-        print(df)
         v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
         v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
         v1v2_total = v1v2.pop("total")

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -7,9 +7,8 @@ def pluto():
     import os
     from datetime import datetime
     import requests
-    import boto3
+    from src.pluto.helpers import get_branches, get_data
 
-    ENGINE = os.environ["ENGINE"]
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -18,89 +17,33 @@ def pluto():
     """
     )
 
-    def get_branches():
-        branches=set()
-        resource = boto3.resource(
-            "s3",
-            aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"],
-            aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"],
-            endpoint_url = os.environ["AWS_S3_ENDPOINT"]
-        )
-        pub_bucket= resource.Bucket('edm-publishing')
-        for obj in pub_bucket.objects.filter(Prefix='db-pluto/'):
-            dir_name = obj._key.split('/')[1]
-            if not dir_name.isnumeric(): #When I come back on monday: filter out dates
-                branches.add(dir_name)
-        return branches
+
+
     branches = get_branches()
-    print(branches)
-    engine = create_engine(ENGINE)
+    branch = st.sidebar.selectbox(
+        "select a branch",
+        branches,
+        index=branches.index("317-QAQC-to-DO"),
+    )
 
-    @st.cache(suppress_st_warning=True, allow_output_mutation=True)
-    def get_data():
-        def convert(dt):
-            try:
-                d = datetime.strptime(dt, "%Y/%m/%d")
-                return d.strftime("%m/%d/%y")
-            except BaseException:
-                return dt
-
-        engine = create_engine(ENGINE)
-        df_mismatch = pd.read_sql("SELECT * FROM dcp_pluto.qaqc_mismatch", con=engine)
-        df_null = pd.read_sql("SELECT * FROM dcp_pluto.qaqc_null", con=engine)
-        df_aggregate = pd.read_sql("SELECT * FROM dcp_pluto.qaqc_aggregate", con=engine)
-        source_data_versions = pd.read_csv(
-            "https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/latest/output/source_data_versions.csv"
-        )
-        sdv = source_data_versions.to_dict("records")
-        version = {}
-        for i in sdv:
-            version[i["schema_name"]] = i["v"]
-        version_text = f"""
-            Department of City Planning – E-Designations: ***{convert(version['dcp_edesignation'])}***  
-            Department of City Planning – Georeferenced NYC Zoning Maps: ***{convert(version['dcp_zoningmapindex'])}***  
-            Department of City Planning – NYC City Owned and Leased Properties: ***{convert(version['dcp_colp'])}***  
-            Department of City Planning – NYC GIS Zoning Features: ***{convert(version['dcp_zoningdistricts'])}***  
-            Department of City Planning – Political and Administrative Districts: ***{convert(version['dcp_cdboundaries_wi'])}***  
-            Department of City Planning – Geosupport version: ***{convert(version['dcp_cdboundaries_wi'])}***  
-            Department of Finance – Digital Tax Map (DTM): ***{convert(version['dof_dtm'])}***  
-            Department of Finance – Mass Appraisal System (CAMA): ***{convert(version['pluto_input_cama_dof'])}***  
-            Department of Finance – Property Tax System (PTS): ***{convert(version['pluto_pts'])}***  
-            Landmarks Preservation Commission – Historic Districts: ***{convert(version['lpc_historic_districts'])}***  
-            Landmarks Preservation Commission – Individual Landmarks: ***{convert(version['lpc_landmarks'])}***  
-        """
-        log = requests.get(
-            "https://raw.githubusercontent.com/NYCPlanning/db-pluto/master/maintenance/log.md"
-        ).text
-        return (
-            df_mismatch,
-            df_null,
-            df_aggregate,
-            source_data_versions,
-            version_text,
-            log,
-        )
-
-    (
-        df_mismatch,
-        df_null,
-        df_aggregate,
-        source_data_versions,
-        version_text,
-        log,
-    ) = get_data()
+    data = get_data(branch)
 
     versions = [
-        i[0]
-        for i in engine.execute(
-            """
-            SELECT table_name
-            FROM information_schema.tables
-            WHERE table_schema = 'dcp_pluto'
-            AND table_name !~*'qaqc|latest';
-            """
-        ).fetchall()
-    ]
+        "19v1",
+        "19v2",
+        "20v1",
+        "20v2",
+        "20v3",
+        "20v4",
+        "20v5",
+        "20v6",
+        "20v7",
+        "20v8",
+        "21v1",
+        "21v2",
+        "21v3",
+        "21v4",
+        "22v1"]
 
     versions_order = [
         "19v1",
@@ -129,14 +72,13 @@ def pluto():
         "22v10",
         "22v11",
         "22v12",
-        "23v1"
-
+        "23v1",
     ]
 
     v1 = st.sidebar.selectbox(
         "Pick a version of PLUTO:", versions, index=len(versions) - 1
     )
-    
+
     v2 = versions_order[versions_order.index(v1) - 1]
     v3 = versions_order[versions_order.index(v1) - 2]
 
@@ -158,7 +100,7 @@ def pluto():
     st.text(
         f"Current version: {v1}, Previous version: {v2}, Previous Previous version: {v3}"
     )
-# test
+    # test
     def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
         finance_columns = [
             "assessland",
@@ -319,8 +261,10 @@ def pluto():
             :,
         ]
 
-        v1v2 = df.loc[df_mismatch.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-        v2v3 = df.loc[df_mismatch.pair == f"{v2} - {v3}", :].to_dict("records")[0]
+        print(f'v1={v1}, v2={v2},')
+        print(df)
+        v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
+        v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
         v1v2_total = v1v2.pop("total")
         v2v3_total = v2v3.pop("total")
 
@@ -466,9 +410,9 @@ def pluto():
                 mode="lines",
                 name=title,
                 hovertemplate="<b>%{x} %{text}</b>",
-                text=text
-            ) 
-       
+                text=text,
+            )
+
         fig = go.Figure()
         fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
         fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
@@ -542,18 +486,57 @@ def pluto():
         """
         )
 
-    create_mismatch(df_mismatch, v1, v2, v3, condo, mapped)
+    def create_expected(df, v1, v2):
 
-    create_null(df_null, v1, v2, v3, condo, mapped)
+        exp = df[df["v"] == f"{v1}|{v2}"]
 
-    create_aggregate(df_aggregate, v1, v2, v3, condo, mapped)
+        exp_records = exp.to_dict("records")
+        v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]
+        v2_exp = [i["expected"] for i in exp_records if i["v"] == v2][0]
+        for field in [
+            "zonedist1",
+            "zonedist2",
+            "zonedist3",
+            "zonedist4",
+            "overlay1",
+            "overlay2",
+            "spdist1",
+            "spdist2",
+            "spdist3",
+            "ext",
+            "proxcode",
+            "irrlotcode",
+            "lottype",
+            "bsmtcode",
+            "bldgclasslanduse",
+        ]:
+            val1 = [i["values"] for i in v1_exp if i["field"] == field][0]
+            val2 = [i["values"] for i in v2_exp if i["field"] == field][0]
+            in1not2 = [i for i in val1 if i not in val2]
+            in2not1 = [i for i in val2 if i not in val1]
+            if len(in1not2) == 0 and len(in2not1) == 0:
+                pass
+            else:
+                st.markdown(f"### Expected value difference for {field}")
+                if len(in1not2) != 0:
+                    st.markdown(f"* in {v1} but not in {v2}:")
+                    st.write(in1not2)
+                if len(in2not1) != 0:
+                    st.markdown(f"* in {v2} but not in {v1}:")
+                    st.write(in2not1)
+
+    create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
+
+    create_null(data["df_null"], v1, v2, v3, condo, mapped)
+
+    create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
 
     st.header("Source Data Versions")
     code = st.checkbox("code")
     if code:
-        st.code(version_text)
+        st.code(data["version_text"])
     else:
-        st.markdown(version_text)
+        st.markdown(data["version_text"])
 
     # EXPECTED VALUE
     st.header("Expected Value Comparison")
@@ -561,50 +544,4 @@ def pluto():
         "if nothing showed up, then it means there aren't any expected value change"
     )
 
-    @st.cache(suppress_st_warning=True, allow_output_mutation=True)
-    def get_expected_value(v1, v2):
-        engine = create_engine(ENGINE)
-        df = pd.read_sql(
-            f"SELECT * FROM dcp_pluto.qaqc_expected where v ~* '{v1}|{v2}'", con=engine
-        )
-        return df
-
-    exp = get_expected_value(v1, v2)
-    exp_records = exp.to_dict("records")
-    v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]
-    v2_exp = [i["expected"] for i in exp_records if i["v"] == v2][0]
-    for field in [
-        "zonedist1",
-        "zonedist2",
-        "zonedist3",
-        "zonedist4",
-        "overlay1",
-        "overlay2",
-        "spdist1",
-        "spdist2",
-        "spdist3",
-        "ext",
-        "proxcode",
-        "irrlotcode",
-        "lottype",
-        "bsmtcode",
-        "bldgclasslanduse",
-    ]:
-        val1 = [i["values"] for i in v1_exp if i["field"] == field][0]
-        val2 = [i["values"] for i in v2_exp if i["field"] == field][0]
-        in1not2 = [i for i in val1 if i not in val2]
-        in2not1 = [i for i in val2 if i not in val1]
-        if len(in1not2) == 0 and len(in2not1) == 0:
-            pass
-        else:
-            st.markdown(f"### Expected value difference for {field}")
-            if len(in1not2) != 0:
-                st.markdown(f"* in {v1} but not in {v2}:")
-                st.write(in1not2)
-            if len(in2not1) != 0:
-                st.markdown(f"* in {v2} but not in {v1}:")
-                st.write(in2not1)
-
-    seelog = st.sidebar.checkbox("see build log?")
-    if seelog:
-        st.sidebar.markdown(log)
+    create_expected(data["df_expected"], v1, v2)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -488,7 +488,7 @@ def pluto():
 
     def create_expected(df, v1, v2):
 
-        exp = df[df["v"] == f"{v1}|{v2}"]
+        exp = df[df["v"].isin([v1, v2])]
 
         exp_records = exp.to_dict("records")
         v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]


### PR DESCRIPTION
This is a pretty straightforward upgrade, doesn't change any functionality in the app. `get_data` function is moved to a helper module like facDB. 

The only new content is code to get branch names from digital ocean instead of github. I use logic to not include folders named after dates and versions. Right now those folder don't have any QAQC files. What I had in mind is that we want users to pull from main (for external review) and feature branches (for developers).

This should be reviewed but not merged until we finalize the [changes on the pluto side](https://github.com/NYCPlanning/db-pluto/pull/355)