### PR TITLE
Remove unused branches in facdb  `select a branch` dropdown

### DIFF
--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -40,14 +40,14 @@ def facdb():
     def get_branches():
         url = "https://api.github.com/repos/nycplanning/db-facilities/branches"
         response = requests.get(url).json()
-        return [r["name"] for r in response]
+        all_branches = [r["name"] for r in response]
+        return [b for b in all_branches if b not in remove_branches] #filter branches no longer needed in qaqc
 
     branches = get_branches()
-    filter_branches = [b for b in branches if b not in remove_branches]
     branch = st.sidebar.selectbox(
         "select a branch",
-        filter_branches,
-        index=filter_branches.index("develop"),
+        branches,
+        index=branches.index("develop"),
     )
     if st.sidebar.button(
         label="Refresh data", help="Download newest files from Digital Ocean"

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -8,7 +8,6 @@ import requests
 from src.facdb.helpers import get_data, remove_branches
 
 
-
 def facdb():
     st.title("Facilities DB QAQC")
 
@@ -41,7 +40,9 @@ def facdb():
         url = "https://api.github.com/repos/nycplanning/db-facilities/branches"
         response = requests.get(url).json()
         all_branches = [r["name"] for r in response]
-        return [b for b in all_branches if b not in remove_branches] #filter branches no longer needed in qaqc
+        return [
+            b for b in all_branches if b not in remove_branches
+        ]  # filter branches no longer needed in qaqc
 
     branches = get_branches()
     branch = st.sidebar.selectbox(
@@ -52,7 +53,7 @@ def facdb():
     if st.sidebar.button(
         label="Refresh data", help="Download newest files from Digital Ocean"
     ):
-        print("button pressed")
+
         st.experimental_memo.clear()
         get_data(branch)
 

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -5,7 +5,8 @@ import pydeck as pdk  # type: ignore
 import plotly.graph_objects as go  # type: ignore
 import plotly.express as px  # type: ignore
 import requests
-from src.facdb.helpers import get_data
+from src.facdb.helpers import get_data, remove_branches
+
 
 
 def facdb():
@@ -42,10 +43,11 @@ def facdb():
         return [r["name"] for r in response]
 
     branches = get_branches()
+    filter_branches = [b for b in branches if b not in remove_branches]
     branch = st.sidebar.selectbox(
         "select a branch",
-        branches,
-        index=branches.index("develop"),
+        filter_branches,
+        index=filter_branches.index("develop"),
     )
     if st.sidebar.button(
         label="Refresh data", help="Download newest files from Digital Ocean"

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -21,6 +21,8 @@ remove_branches = [
     "563-Update-TextileDrop",
     "567_MOEOProgramName",
     "574-Rename-POPS-Number",
+    "Address-Poetry-Merge-Conflict", 
+    "dataloading-issue-template",
 ]
 
 @st.experimental_memo

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -21,13 +21,13 @@ remove_branches = [
     "563-Update-TextileDrop",
     "567_MOEOProgramName",
     "574-Rename-POPS-Number",
-    "Address-Poetry-Merge-Conflict", 
+    "Address-Poetry-Merge-Conflict",
     "dataloading-issue-template",
 ]
 
+
 @st.experimental_memo
 def get_data(branch):
-    print("running get_data()")
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-facilities/{branch}/latest/output"
     qc_diff = pd.read_csv(f"{url}/qc_diff.csv")
     qc_captype = pd.read_csv(f"{url}/qc_captype.csv")

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -1,6 +1,27 @@
 import streamlit as st
 import pandas as pd
 
+remove_branches = [
+    "524_AddPOPSNumber",
+    "528-Manager-Address-Approach",
+    "528-usairports-update-source",
+    "530-docker-compose-postgres-install-issue",
+    "532-update-moeo-socialservicesitelocations",
+    "534-q2-update-check-dataloading",
+    "535-Fix-Fooddrops",
+    "543-No-Build-On-Push",
+    "546-Metadata-Output",
+    "547-update-dcp-pops-version",
+    "549-QAQC-compare-to-all-records",
+    "553-Clarify-QAQC-Mapped",
+    "554-update-dot-data",
+    "558-remove-special-character-moeo-sonyc",
+    "559-update-projection-shapefile",
+    "560-doe-lcgms-latest",
+    "563-Update-TextileDrop",
+    "567_MOEOProgramName",
+    "574-Rename-POPS-Number",
+]
 
 @st.experimental_memo
 def get_data(branch):


### PR DESCRIPTION
Addresses issue #51

Got a list of branches that were not used for the FacDB QAQC since the 2022-Q2-Build and removed them from the `select a branch` dropdown menu