### PR TITLE
Add CPDB Page, setup.py, and update python in dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim as build
+FROM python:3.9-slim as build
 
 RUN apt update && apt install -y git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim as build
+FROM python:3.9-slim as build
 
 WORKDIR /app
 

--- a/index.py
+++ b/index.py
@@ -4,6 +4,7 @@ from src.ztl import ztl
 from src.facdb.facdb import facdb
 from src.devdb import devdb
 from src.geocode import geocode
+from src.cpdb.cpdb import cpdb
 from src.home import home
 import requests
 import datetime
@@ -15,6 +16,7 @@ datasets = {
     "Facilities DB": facdb,
     "Developments DB": devdb,
     "Geosupport Demo": geocode,
+    "Capital Projects DB": cpdb
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
         "numpy",
         "streamlit",
         "plotly",
+        "python-dotenv",
+        "boto3",
     ],
     zip_safe=False,
 )

--- a/src/cpdb/cpdb.py
+++ b/src/cpdb/cpdb.py
@@ -1,0 +1,17 @@
+import streamlit as st  # type: ignore
+import pandas as pd
+from src.cpdb.helpers import get_data
+
+def cpdb():
+    st.title("Capital Projects DB QAQC")
+    branch = st.sidebar.selectbox(
+        "select a branch",
+        ['main']
+    )
+    data = get_data(branch)
+
+    st.header('Managing Agency Summary Stats')
+    st.dataframe(data['magency'])
+
+    st.header("Sponsoring Agency Summary Stats")
+    st.dataframe(data['sagency'])

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -1,0 +1,31 @@
+from io import StringIO
+import streamlit as st
+import os
+import pandas as pd
+import boto3
+from dotenv import load_dotenv
+
+load_dotenv()
+
+def get_data(branch) -> dict:
+    rv = {}
+    # url = f"https://edm-private.nyc3.digitaloceanspaces.com/db-cpdb/{branch}/latest/output/analysis"
+
+    client = boto3.client(
+        "s3",
+        aws_access_key_id = os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY"),
+        endpoint_url = os.getenv("AWS_S3_ENDPOINT")
+    )
+    for table in ['magency', 'sagency']:
+        obj = client.get_object(
+            Bucket="edm-private",
+            Key=f"db-cpdb/{branch}/latest/output/analysis/cpdb_summarystats_{table}.csv",
+        )
+        s = str(obj["Body"].read(), "utf8")
+        data = StringIO(s)
+        df = pd.read_csv(data, encoding='utf8')
+        rv[table] = df
+    # rv['magency'] = pd.read_csv(f"{url}/cpdb_summarystats_magency.csv")
+    # rv['sagency'] = pd.read_csv(f"{url}/cpdb_summarystats_sagency.csv")
+    return rv

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -9,7 +9,6 @@ load_dotenv()
 
 def get_data(branch) -> dict:
     rv = {}
-    # url = f"https://edm-private.nyc3.digitaloceanspaces.com/db-cpdb/{branch}/latest/output/analysis"
 
     client = boto3.client(
         "s3",
@@ -26,6 +25,5 @@ def get_data(branch) -> dict:
         data = StringIO(s)
         df = pd.read_csv(data, encoding='utf8')
         rv[table] = df
-    # rv['magency'] = pd.read_csv(f"{url}/cpdb_summarystats_magency.csv")
-    # rv['sagency'] = pd.read_csv(f"{url}/cpdb_summarystats_sagency.csv")
+
     return rv


### PR DESCRIPTION
**Add CPDB Page**

Addresses issue #46 

Nothing new happening here. These changes were all pair coded by the team earlier this week in which we added the cpdb page:

- Create folder structure similar to `facdb` and `pluto` where we have two .py files (helpers.py and cpdb.py) 
- Get the data from DO edm-private space
- View the `Managing Agency Summary Stats` and `Sponsoring Agency Summary Stats` tables in the app 

**Update setup.py**

Addresses issue #57 

The setup.py file is outdated after our latest changes to the app. When I was testing the app locally, I was not able to view the latest changes so I added the necessary modules into the setup.py which should fix any issues. You will need to rebuild the dev container to test these changes. Also make sure you have the latest secrets in your .env. Eventually we might just want to use poetry but in the meantime this is a necessary change to keep the qaqc development moving 

**Update python version in dev container**

Addresses issue #58 
I updated the version of python in the dev container from 3.6 to 3.9. I noticed when rebuilding my container that 3.6 is no longer supported by boto3 so thought this was a necessary updgrade -  it is time we updated to a newer version of python anyway because python 3.6 is a few years old at this point. This should be tested further by each engineer but I don't think (???) it should cause any issues. 