### PR TITLE
63 add pluto corrections summary by field

### DIFF
--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -91,10 +91,6 @@ def blacklist_branches(branches):
     return rv
 
 
-<<<<<<< HEAD
-def csv_from_DO(url, kwargs={}):
-    return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
-=======
 def csv_from_DO(url, kwargs={}):
     return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
 
@@ -115,4 +111,3 @@ def s3_resource():
         aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
         endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
     )
->>>>>>> 4849900... Add in pluto summary graph by field

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -520,8 +520,8 @@ def pluto():
                 return df.loc[df['version'] == version]
         
         st.header("Manual Corrections")
-
-        version = st.selectbox("Select a Version", np.insert(df.version.unique(), 0, 'All'))
+        version_dropdown = np.insert(np.flip(np.sort(df.version.dropna().unique())), 0, 'All')
+        version = st.selectbox("Select a Version", version_dropdown)
 
         df = filter_by_version(df, version)
         

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -493,16 +493,6 @@ def pluto():
                     st.write(in2not1)
 
     def create_corrections(df):
-        def generate_trace(v1):
-            hovertemplate = "<b>%{x} - %{y}</b>"
-            return go.Scatter(
-                y=v1,
-                x=v1.index,
-                mode="lines",
-                name="Pluto Corrections",
-                hovertemplate=hovertemplate,
-                text=v1.index
-            )
         def version_title_text(version):
             if version == "All":
                 return "All Versions"

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -519,7 +519,8 @@ def pluto():
         st.plotly_chart(figure)
         st.info(
             """
-            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. 
+            See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
             in the PLUTO change file.
             """
         )

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -517,6 +517,12 @@ def pluto():
         
         st.header("Corrections")
         st.plotly_chart(figure)
+        st.info(
+            """
+            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+            in the PLUTO change file.
+            """
+        )
 
     create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -491,6 +491,33 @@ def pluto():
                     st.markdown(f"* in {v2} but not in {v1}:")
                     st.write(in2not1)
 
+    def create_corrections(df):
+        def generate_trace(v1):
+            hovertemplate = "<b>%{x} - %{y}</b>"
+            return go.Scatter(
+                y=v1,
+                x=v1.index,
+                mode="lines",
+                name="Pluto Corrections",
+                hovertemplate=hovertemplate,
+                text=v1.index
+            )
+        def generate_graph(v1):
+            fig = go.Figure()
+            fig.add_trace(generate_trace(v1))
+            fig.update_yaxes(title_text="# of Corrected Records")
+            fig.update_xaxes(title_text="Field")
+            fig.update_layout(title="Corrected Records by Field", template="plotly_white")
+            return fig
+
+        def field_correction_counts(df):
+            return df.groupby(['field']).size()
+        
+        figure = generate_graph(field_correction_counts(df))
+        
+        st.header("Corrections")
+        st.plotly_chart(figure)
+
     create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 
     create_null(data["df_null"], v1, v2, v3, condo, mapped)
@@ -511,3 +538,6 @@ def pluto():
     )
 
     create_expected(data["df_expected"], v1, v2)
+
+    create_corrections(data["pluto_corrections"])
+

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -4,6 +4,7 @@ def pluto():
     import numpy as np
     from sqlalchemy import create_engine
     import plotly.graph_objects as go
+    import plotly.express as px
     import os
     from datetime import datetime
     import requests
@@ -502,20 +503,40 @@ def pluto():
                 hovertemplate=hovertemplate,
                 text=v1.index
             )
-        def generate_graph(v1):
-            fig = go.Figure()
-            fig.add_trace(generate_trace(v1))
-            fig.update_yaxes(title_text="# of Corrected Records")
-            fig.update_xaxes(title_text="Field")
-            fig.update_layout(title="Corrected Records by Field", template="plotly_white")
+        def version_title_text(version):
+            if version == "All":
+                return "All Versions"
+            else:
+                return f"Version {version}"
+            
+        def generate_graph(v1, version):
+            fig = px.bar(
+                v1, 
+                x='field',
+                 y='size', 
+                 text='size',
+                 title=f"Corrected Records by Field for {version_title_text(version)}", 
+                 labels={'size': 'Count of Corrected Records', 'field': 'Altered Field'}
+            )
             return fig
 
         def field_correction_counts(df):
-            return df.groupby(['field']).size()
+            return df.groupby(['field']).size().to_frame('size').reset_index()
         
-        figure = generate_graph(field_correction_counts(df))
+        def filter_by_version(df, version):
+            if version == 'All':
+                return df
+            else:
+                return df.loc[df['version'] == version]
         
-        st.header("Corrections")
+        st.header("Manual Corrections")
+
+        version = st.selectbox("Select a Version", np.insert(df.version.unique(), 0, 'All'))
+
+        df = filter_by_version(df, version)
+        
+        figure = generate_graph(field_correction_counts(df), version)
+
         st.plotly_chart(figure)
         st.info(
             """


### PR DESCRIPTION
Because we don't have a pluto corrections not applied table nor an existing way to compare corrections across versions, this just includes a graph for pluto corrections by field. Ideas for additional language around this welcome/ are other splits useful (by reason, for ex.?)

All of the correction records in pluto have a version number that identifies what version they were first introduced in. With the not_applied data it will make more sense, but you could theoretically want to know, in the latest version of pluto, how many corrections were applied that were first identified in version 20v8? Or by leaving this on all versions, you'd be showing all of the corrections applied for the current version, regardless of when they were first introduced