### PR TITLE
63 pluto corrections applied and not applied

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "plotly",
         "python-dotenv",
         "boto3",
+        "streamlit-aggrid"
     ],
     zip_safe=False,
 )

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -91,10 +91,6 @@ def blacklist_branches(branches):
     return rv
 
 
-<<<<<<< HEAD
-def csv_from_DO(url, kwargs={}):
-    return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
-=======
 def csv_from_DO(url, kwargs={}):
     return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
 
@@ -115,4 +111,3 @@ def s3_resource():
         aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
         endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
     )
->>>>>>> 4849900... Add in pluto summary graph by field

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -27,8 +27,18 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
         zip_filename=f"db-pluto/{branch}/latest/output/pluto_corrections.zip",
         bucket=BUCKET_NAME
     )
+
     rv["pluto_corrections"] = unzip_csv(
         csv_filename="pluto_corrections.csv",
+        zipfile=pluto_corrections_zip
+    )
+    
+    rv["pluto_corrections_applied"] = unzip_csv(
+        csv_filename="pluto_corrections_applied.csv",
+        zipfile=pluto_corrections_zip
+    )
+    rv["pluto_corrections_not_applied"] = unzip_csv(
+        csv_filename="pluto_corrections_not_applied.csv",
         zipfile=pluto_corrections_zip
     )
 

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -105,8 +105,11 @@ def csv_from_DO(url, kwargs={}):
     return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
 
 def unzip_csv(csv_filename, zipfile):
-    with zipfile.open(csv_filename) as csv:
-        return pd.read_csv(csv, true_values=["t"], false_values=["f"])
+    try:
+        with zipfile.open(csv_filename) as csv:
+            return pd.read_csv(csv, true_values=["t"], false_values=["f"])
+    except: 
+        return None
     
 def zip_from_DO(zip_filename, bucket):
     zip_obj = s3_resource().Object(bucket_name=bucket, key=zip_filename)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -4,7 +4,6 @@ def pluto():
     import numpy as np
     from sqlalchemy import create_engine
     import plotly.graph_objects as go
-    import plotly.express as px
     import os
     from datetime import datetime
     import requests
@@ -49,78 +48,6 @@ def pluto():
         v1 = st.sidebar.selectbox(
             "Pick a version of PLUTO:",
             versions,  # index=len(versions) - 1
-        )
-
-        v2 = versions[versions.index(v1) + 1]
-        v3 = versions[versions.index(v1) + 2]
-
-        condo = st.sidebar.checkbox("condo only")
-        mapped = st.sidebar.checkbox("mapped only")
-        st.sidebar.markdown(
-            """
-        These reports compare the version selected with the previous version (in blue)
-        and the differences between the previous two versions (in red).
-
-        There is an option to look at just **condo lots**. Condos make up a small percentage of lots,
-        but contain a large percentage of the residential housing.
-
-        A second option lets you look at all lots or just **mapped lots**.
-        Unmapped lots are those with a record in PTS, but no corresponding record in DTM.
-        This happens because DOF updates are not in sync.
-        """
-        )
-        st.text(
-            f"Current version: {v1}, Previous version: {v2}, Previous Previous version: {v3}"
-        )
-        # test
-        def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
-        finance_columns = [
-            "assessland",
-            "assesstot",
-            "exempttot",
-            "taxmap",
-            "appbbl",
-            "appdate",
-            "plutomapid",
-        ]
-
-        area_columns = [
-            "lotarea",
-            "bldgarea",
-            "builtfar",
-            "comarea",
-            "resarea",
-            "officearea",
-            "retailarea",
-            "garagearea",
-            "strgearea",
-            "factryarea",
-            "otherarea",
-            "areasource",
-        ]
-
-        zoning_columns = [
-            "residfar",
-            "commfar",
-            "facilfar",
-            "zonedist1",
-            "zonedist2",
-            "zonedist3",
-            "zonedist4",
-            "overlay1",
-            "overlay2",
-            "spdist1",
-            "spdist2",
-            "spdist3",
-            "ltdheight",
-            "splitzone",
-            "zonemap",
-            "zmcode",
-            "edesignum",
-        ]
-
-        v1 = st.sidebar.selectbox(
-            "Pick a version of PLUTO:", versions, #index=len(versions) - 1
         )
 
         v2 = versions[versions.index(v1) + 1]
@@ -442,48 +369,18 @@ def pluto():
                 "firm07_flag",
                 "pfirm15_flag",
             ]
-            x = [(v1[i] / v2[i] - 1) * 100 for i in y]
-            real_v1 = [v1[i] for i in y]
-            real_v2 = [v2[i] for i in y]
-            hovertemplate = "<b>%{x}</b> %{text}"
-            text = []
-            for n in range(len(y)):
-                text.append(
-                    "Percent Change: {:.2f}%<br>Prev: {:.2E} Current: {:.2E}".format(
-                        x[n], real_v1[n], real_v2[n]
-                    )
-                )
-            return go.Scatter(
-                x=y,
-                y=x,
-                mode="lines",
-                name=f"{_v1} - {_v2}",
-                hovertemplate=hovertemplate,
-                text=text,
-            )
 
-        fig = go.Figure()
-        fig.add_trace(generate_graph(v1, v2))
-        fig.add_trace(generate_graph(v2, v3))
-        fig.update_layout(
-            title="Aggregate graph",
-            template="plotly_white",
-            yaxis={"title": "Percent Change"},
-        )
-        st.plotly_chart(fig)
-        st.write(df)
-        st.info(
-            """
-         The aggregate graph provides insights into the magnitude of changes, complementing the mismatch graph's functionality of showing the number of lots with a changed value.
-         For example, the mismatch graph for finance may show that over 90% of lots get an updated assessment when the tentative roll is released.
-         The aggregate graph may show that the aggregated sum of assessments increased by 5% compared with the previous version.\n
-         Totals for assessland, assesstot, and exempttot should only change in February and June.\n
-         Special Notes:\n
-         1. Y-axis represents percent change over the previous version. \n
-         2. Totals for assessland, assesstot, and exempttot should only change in February and June.\n
-         3. Pay attention to any large changes to residential units (unitsres).
-        """
-        )
+            def generate_graph(r, total, title):
+                y = [r[i] for i in x]
+                text = [f"{round(r[i]/total*100, 2)}%" for i in x]
+                return go.Scatter(
+                    x=x,
+                    y=y,
+                    mode="lines",
+                    name=title,
+                    hovertemplate="<b>%{x} %{text}</b>",
+                    text=text,
+                )
 
             fig = go.Figure()
             fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
@@ -533,28 +430,45 @@ def pluto():
                     "pfirm15_flag",
                 ]
                 x = [(v1[i] / v2[i] - 1) * 100 for i in y]
-                hovertemplate = "<b>%{x} %{text}</b>"
+                real_v1 = [v1[i] for i in y]
+                real_v2 = [v2[i] for i in y]
+                hovertemplate = "<b>%{x}</b> %{text}"
+                text = []
+                for n in range(len(y)):
+                    text.append(
+                        "Percent Change: {:.2f}%<br>Prev: {:.2E} Current: {:.2E}".format(
+                            x[n], real_v1[n], real_v2[n]
+                        )
+                    )
                 return go.Scatter(
                     x=y,
                     y=x,
                     mode="lines",
                     name=f"{_v1} - {_v2}",
                     hovertemplate=hovertemplate,
-                    text=[f"{round(i,2)}%" for i in x],
+                    text=text,
                 )
 
             fig = go.Figure()
             fig.add_trace(generate_graph(v1, v2))
             fig.add_trace(generate_graph(v2, v3))
-            fig.update_layout(title="Aggregate graph", template="plotly_white")
+            fig.update_layout(
+                title="Aggregate graph",
+                template="plotly_white",
+                yaxis={"title": "Percent Change"},
+            )
             st.plotly_chart(fig)
             st.write(df)
             st.info(
                 """
-            In addition to looking at the number of lots with a changed value, it’s important to look at the magnitude of the change.
+            The aggregate graph provides insights into the magnitude of changes, complementing the mismatch graph's functionality of showing the number of lots with a changed value.
             For example, the mismatch graph for finance may show that over 90% of lots get an updated assessment when the tentative roll is released.
-            The aggregate graph may show that the aggregated sum increased by 5%. Totals for assessland, assesstot, and exempttot should only change in February and June.
-            Pay attention to any large changes to residential units (unitsres).
+            The aggregate graph may show that the aggregated sum of assessments increased by 5% compared with the previous version.\n
+            Totals for assessland, assesstot, and exempttot should only change in February and June.\n
+            Special Notes:\n
+            1. Y-axis represents percent change over the previous version. \n
+            2. Totals for assessland, assesstot, and exempttot should only change in February and June.\n
+            3. Pay attention to any large changes to residential units (unitsres).
             """
             )
 
@@ -596,6 +510,7 @@ def pluto():
                     if len(in2not1) != 0:
                         st.markdown(f"* in {v2} but not in {v1}:")
                         st.write(in2not1)
+
         create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 
         create_null(data["df_null"], v1, v2, v3, condo, mapped)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -538,7 +538,8 @@ def pluto():
         st.plotly_chart(figure)
         st.info(
             """
-            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. 
+            See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
             in the PLUTO change file.
             """
         )

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -539,8 +539,8 @@ def pluto():
                 return df.loc[df['version'] == version]
         
         st.header("Manual Corrections")
-
-        version = st.selectbox("Select a Version", np.insert(df.version.unique(), 0, 'All'))
+        version_dropdown = np.insert(np.flip(np.sort(df.version.dropna().unique())), 0, 'All')
+        version = st.selectbox("Select a Version", version_dropdown)
 
         df = filter_by_version(df, version)
         

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -25,9 +25,9 @@ def pluto():
         index=branches.index("main"),
     )
 
-    data = get_data(branch)
-
     report_type = st.sidebar.selectbox("Choose a Report Type", ["Compare with Previous Version", "Review Manual Corrections"])
+
+    data = get_data(branch)
 
     def version_comparison_report(data):
         versions = [

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -9,6 +9,7 @@ def pluto():
     from datetime import datetime
     import requests
     from src.pluto.helpers import get_branches, get_data
+    from st_aggrid import AgGrid
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -560,7 +561,7 @@ def pluto():
             def display_corrections_df(corrections):
                 corrections = corrections.sort_values(by=['version', 'reason', 'bbl'], ascending=[False, True, True])
 
-                st.dataframe(corrections)
+                AgGrid(corrections)
 
             def field_correction_counts(df):
                 return df.groupby(['field']).size().to_frame('size').reset_index()
@@ -635,6 +636,6 @@ def pluto():
 
     if report_type == 'Compare with Previous Version':
         version_comparison_report(data)
-    else:
+    elif report_type == "Review Manual Corrections":
         manual_corrections_report(data)
     

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -26,53 +26,54 @@ def pluto():
 
     data = get_data(branch)
 
-    versions = [
-        '22v2',
-        "22v1",
-        "21v4",
-        "21v3",
-        "21v2",
-        "21v1",
-        "20v8",
-        "20v7",
-        "20v6",
-        "20v5",
-        "20v4",
-        "20v3",
-        "20v2",
-        "20v1",
-        "19v2",
-        "19v1",
-    ]
+    def version_comparison_report(data):
+        versions = [
+            "22v2",
+            "22v1",
+            "21v4",
+            "21v3",
+            "21v2",
+            "21v1",
+            "20v8",
+            "20v7",
+            "20v6",
+            "20v5",
+            "20v4",
+            "20v3",
+            "20v2",
+            "20v1",
+            "19v2",
+            "19v1",
+        ]
 
-    v1 = st.sidebar.selectbox(
-        "Pick a version of PLUTO:",
-        versions,  # index=len(versions) - 1
-    )
+        v1 = st.sidebar.selectbox(
+            "Pick a version of PLUTO:",
+            versions,  # index=len(versions) - 1
+        )
 
-    v2 = versions[versions.index(v1) + 1]
-    v3 = versions[versions.index(v1) + 2]
+        v2 = versions[versions.index(v1) + 1]
+        v3 = versions[versions.index(v1) + 2]
 
-    condo = st.sidebar.checkbox("condo only")
-    mapped = st.sidebar.checkbox("mapped only")
-    st.sidebar.markdown(
+        condo = st.sidebar.checkbox("condo only")
+        mapped = st.sidebar.checkbox("mapped only")
+        st.sidebar.markdown(
+            """
+        These reports compare the version selected with the previous version (in blue)
+        and the differences between the previous two versions (in red).
+
+        There is an option to look at just **condo lots**. Condos make up a small percentage of lots,
+        but contain a large percentage of the residential housing.
+
+        A second option lets you look at all lots or just **mapped lots**.
+        Unmapped lots are those with a record in PTS, but no corresponding record in DTM.
+        This happens because DOF updates are not in sync.
         """
-    These reports compare the version selected with the previous version (in blue)
-    and the differences between the previous two versions (in red).
-
-    There is an option to look at just **condo lots**. Condos make up a small percentage of lots,
-    but contain a large percentage of the residential housing.
-
-    A second option lets you look at all lots or just **mapped lots**.
-    Unmapped lots are those with a record in PTS, but no corresponding record in DTM.
-    This happens because DOF updates are not in sync.
-    """
-    )
-    st.text(
-        f"Current version: {v1}, Previous version: {v2}, Previous Previous version: {v3}"
-    )
-    # test
-    def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
+        )
+        st.text(
+            f"Current version: {v1}, Previous version: {v2}, Previous Previous version: {v3}"
+        )
+        # test
+        def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
         finance_columns = [
             "assessland",
             "assesstot",
@@ -118,301 +119,271 @@ def pluto():
             "edesignum",
         ]
 
-        geo_columns = [
-            "cd",
-            # "bct2020",
-            # "bctcb2020",
-            "ct2010",
-            "cb2010",
-            "schooldist",
-            "council",
-            "zipcode",
-            "firecomp",
-            "policeprct",
-            "healtharea",
-            "sanitboro",
-            "sanitsub",
-            "address",
-            "borocode",
-            "bbl",
-            "tract2010",
-            "xcoord",
-            "ycoord",
-            "longitude",
-            "latitude",
-            "sanborn",
-            "edesignum",
-            "sanitdistrict",
-            "healthcenterdistrict",
-            "histdist",
-            "firm07_flag",
-            "pfirm15_flag",
-        ]
-
-        bldg_columns = [
-            "bldgclass",
-            "landuse",
-            "easements",
-            "ownertype",
-            "ownername",
-            "numbldgs",
-            "numfloors",
-            "unitsres",
-            "unitstotal",
-            "lotfront",
-            "lotdepth",
-            "bldgfront",
-            "bldgdepth",
-            "ext",
-            "proxcode",
-            "irrlotcode",
-            "lottype",
-            "bsmtcode",
-            "yearbuilt",
-            "yearalter1",
-            "yearalter2",
-            "landmark",
-            "condono",
-        ]
-
-        groups = [
-            {
-                "title": "Mismatch graph -- finance",
-                "columns": finance_columns,
-                "description": """
-                Assessment and exempt values are updated **twice** a year by DOF.
-                The tentative roll is released in *mid-January* and the final roll is released in *late May*.
-                For PLUTO versions created in February, most lots will show a change in assesstot,
-                with a smaller number of changes for the `assessland` and `exempttot`.
-                There will also be changes in the June version. Other months should see almost no change for these fields.
-                """,
-            },
-            {
-                "title": "Mismatch graph -- area",
-                "columns": area_columns,
-                "description": """
-                The primary source for these fields is **CAMA**.
-                Updates reflect new construction, as well as updates by assessors for the tentative roll.
-                Several thousand lots may have updates in February.
-            """,
-            },
-            {
-                "title": "Mismatch graph -- zoning",
-                "columns": zoning_columns,
-                "description": """
-                Unless DCP does a major rezoning, the number of lots with changed values should be **no more than a couple of hundred**.
-                Lots may get a changed value due to a split/merge or if TRD is cleaning up boundaries between zoning districts.
-                `Residfar`, `commfar`, and `facilfar` should change only when there is a change to `zonedist1` or `overlay1`.
-            """,
-            },
-            {
-                "title": "Mismatch graph -- geo",
-                "columns": geo_columns,
-                "description": """
-                These fields are updated from **Geosupport**. Changes should be minimal unless a municipal service
-                area changes or more high-rise buildings opt into the composite recycling program.
-                Check with GRU if more than a small number of lots have changes to municipal service areas.
-            """,
-            },
-            {
-                "title": "Mismatch graph -- building",
-                "columns": bldg_columns,
-                "description": """
-                Changes in these fields are most common in February, after the tentative roll has been released.
-                Several fields in this group are changed by DCP to improve data quality, including `ownername` and `yearbuilt`.
-                When these changes are first applied, there will be a spike in the number of lots changed.
-            """,
-            },
-        ]
-
-        df = df_mismatch.loc[
-            (df_mismatch.condo == condo)
-            & (df_mismatch.mapped == mapped)
-            & (df_mismatch.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
-            :,
-        ]
-
-        v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-        v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
-        v1v2_total = v1v2.pop("total")
-        v2v3_total = v2v3.pop("total")
-
-        def generate_graph_data(r, total, name, group):
-            r = {key: value for (key, value) in r.items() if key in group}
-            y = [r[i] for i in group]
-            x = group
-            hovertemplate = "<b>%{x} %{text}</b>"
-            text = [f"{round(r[i]/total*100, 2)}%" for i in group]
-            return go.Scatter(
-                x=x,
-                y=y,
-                mode="lines",
-                name=name,
-                hovertemplate=hovertemplate,
-                text=text,
-            )
-
-        def generate_graph(v1v2, v2v3, v1v2_total, v2v3_total, group):
-            fig = go.Figure()
-            fig.add_trace(generate_graph_data(v1v2, v1v2_total, v1v2["pair"], group))
-            fig.add_trace(generate_graph_data(v2v3, v2v3_total, v2v3["pair"], group))
-            return fig
-
-        for group in groups:
-            fig = generate_graph(v1v2, v2v3, v1v2_total, v2v3_total, group["columns"])
-            fig.update_layout(title=group["title"], template="plotly_white")
-            st.plotly_chart(fig)
-            st.info(group["description"])
-        st.write(df)
-
-    def create_null(df_null, v1, v2, v3, condo, mapped):
-        df = df_null.loc[
-            (df_null.condo == condo)
-            & (df_null.mapped == mapped)
-            & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
-            :,
-        ]
-        v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-        v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :].to_dict("records")[0]
-        v1v2_total = v1v2.pop("total")
-        v2v3_total = v2v3.pop("total")
-
-        x = [
-            "borough",
-            "block",
-            "lot",
-            "cd",
-            # "bct2020",
-            # "bctcb2020",
-            "ct2010",
-            "cb2010",
-            "schooldist",
-            "council",
-            "zipcode",
-            "firecomp",
-            "policeprct",
-            "healtharea",
-            "sanitboro",
-            "sanitsub",
-            "address",
-            "zonedist1",
-            "zonedist2",
-            "zonedist3",
-            "zonedist4",
-            "overlay1",
-            "overlay2",
-            "spdist1",
-            "spdist2",
-            "spdist3",
-            "ltdheight",
-            "splitzone",
-            "bldgclass",
-            "landuse",
-            "easements",
-            "ownertype",
-            "ownername",
-            "lotarea",
-            "bldgarea",
-            "comarea",
-            "resarea",
-            "officearea",
-            "retailarea",
-            "garagearea",
-            "strgearea",
-            "factryarea",
-            "otherarea",
-            "areasource",
-            "numbldgs",
-            "numfloors",
-            "unitsres",
-            "unitstotal",
-            "lotfront",
-            "lotdepth",
-            "bldgfront",
-            "bldgdepth",
-            "ext",
-            "proxcode",
-            "irrlotcode",
-            "lottype",
-            "bsmtcode",
-            "assessland",
-            "assesstot",
-            "exempttot",
-            "yearbuilt",
-            "yearalter1",
-            "yearalter2",
-            "histdist",
-            "landmark",
-            "builtfar",
-            "residfar",
-            "commfar",
-            "facilfar",
-            "borocode",
-            "bbl",
-            "condono",
-            "tract2010",
-            "xcoord",
-            "ycoord",
-            "longitude",
-            "latitude",
-            "zonemap",
-            "zmcode",
-            "sanborn",
-            "taxmap",
-            "edesignum",
-            "appbbl",
-            "appdate",
-            "plutomapid",
-            "version",
-            "sanitdistrict",
-            "healthcenterdistrict",
-            "firm07_flag",
-            "pfirm15_flag",
-        ]
-
-        def generate_graph(r, total, title):
-            y = [r[i] for i in x]
-            text = [f"{round(r[i]/total*100, 2)}%" for i in x]
-            return go.Scatter(
-                x=x,
-                y=y,
-                mode="lines",
-                name=title,
-                hovertemplate="<b>%{x} %{text}</b>",
-                text=text,
-            )
-
-        fig = go.Figure()
-        fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
-        fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
-        fig.update_layout(title="Null graph", template="plotly_white")
-        st.plotly_chart(fig)
-        st.write(df)
-        st.info(
-            """
-        The mismatch graphs do not include lots that formerly had a value and are now null, or vice versa.
-        These differences are captured in the null graph, which shows the percent change in lots with a null value.
-        Hovering over a point shows you the number of null records in the more recent file. The number of such changes should be small.
-        """
+        v1 = st.sidebar.selectbox(
+            "Pick a version of PLUTO:", versions, #index=len(versions) - 1
         )
 
-    def create_aggregate(df_aggregate, v1, v2, v3, condo, mapped):
-        df = df_aggregate.loc[
-            (df_aggregate.condo == condo)
-            & (df_aggregate.mapped == mapped)
-            & (df_aggregate.v.isin([v1, v2, v3])),
-            :,
-        ]
-        v1 = df.loc[df.v == v1, :].to_dict("records")[0]
-        v2 = df.loc[df.v == v2, :].to_dict("records")[0]
-        v3 = df.loc[df.v == v3, :].to_dict("records")[0]
+        v2 = versions[versions.index(v1) + 1]
+        v3 = versions[versions.index(v1) + 2]
 
-        def generate_graph(v1, v2):
-            _v1 = v1["v"]
-            _v2 = v2["v"]
+        condo = st.sidebar.checkbox("condo only")
+        mapped = st.sidebar.checkbox("mapped only")
+        st.sidebar.markdown(
+            """
+        These reports compare the version selected with the previous version (in blue)
+        and the differences between the previous two versions (in red).
 
-            y = [
+        There is an option to look at just **condo lots**. Condos make up a small percentage of lots,
+        but contain a large percentage of the residential housing.
+
+        A second option lets you look at all lots or just **mapped lots**.
+        Unmapped lots are those with a record in PTS, but no corresponding record in DTM.
+        This happens because DOF updates are not in sync.
+        """
+        )
+        st.text(
+            f"Current version: {v1}, Previous version: {v2}, Previous Previous version: {v3}"
+        )
+        # test
+        def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
+            finance_columns = [
+                "assessland",
+                "assesstot",
+                "exempttot",
+                "taxmap",
+                "appbbl",
+                "appdate",
+                "plutomapid",
+            ]
+
+            area_columns = [
+                "lotarea",
+                "bldgarea",
+                "builtfar",
+                "comarea",
+                "resarea",
+                "officearea",
+                "retailarea",
+                "garagearea",
+                "strgearea",
+                "factryarea",
+                "otherarea",
+                "areasource",
+            ]
+
+            zoning_columns = [
+                "residfar",
+                "commfar",
+                "facilfar",
+                "zonedist1",
+                "zonedist2",
+                "zonedist3",
+                "zonedist4",
+                "overlay1",
+                "overlay2",
+                "spdist1",
+                "spdist2",
+                "spdist3",
+                "ltdheight",
+                "splitzone",
+                "zonemap",
+                "zmcode",
+                "edesignum",
+            ]
+
+            geo_columns = [
+                "cd",
+                # "bct2020",
+                # "bctcb2020",
+                "ct2010",
+                "cb2010",
+                "schooldist",
+                "council",
+                "zipcode",
+                "firecomp",
+                "policeprct",
+                "healtharea",
+                "sanitboro",
+                "sanitsub",
+                "address",
+                "borocode",
+                "bbl",
+                "tract2010",
+                "xcoord",
+                "ycoord",
+                "longitude",
+                "latitude",
+                "sanborn",
+                "edesignum",
+                "sanitdistrict",
+                "healthcenterdistrict",
+                "histdist",
+                "firm07_flag",
+                "pfirm15_flag",
+            ]
+
+            bldg_columns = [
+                "bldgclass",
+                "landuse",
+                "easements",
+                "ownertype",
+                "ownername",
+                "numbldgs",
+                "numfloors",
                 "unitsres",
+                "unitstotal",
+                "lotfront",
+                "lotdepth",
+                "bldgfront",
+                "bldgdepth",
+                "ext",
+                "proxcode",
+                "irrlotcode",
+                "lottype",
+                "bsmtcode",
+                "yearbuilt",
+                "yearalter1",
+                "yearalter2",
+                "landmark",
+                "condono",
+            ]
+
+            groups = [
+                {
+                    "title": "Mismatch graph -- finance",
+                    "columns": finance_columns,
+                    "description": """
+                    Assessment and exempt values are updated **twice** a year by DOF.
+                    The tentative roll is released in *mid-January* and the final roll is released in *late May*.
+                    For PLUTO versions created in February, most lots will show a change in assesstot,
+                    with a smaller number of changes for the `assessland` and `exempttot`.
+                    There will also be changes in the June version. Other months should see almost no change for these fields.
+                    """,
+                },
+                {
+                    "title": "Mismatch graph -- area",
+                    "columns": area_columns,
+                    "description": """
+                    The primary source for these fields is **CAMA**.
+                    Updates reflect new construction, as well as updates by assessors for the tentative roll.
+                    Several thousand lots may have updates in February.
+                """,
+                },
+                {
+                    "title": "Mismatch graph -- zoning",
+                    "columns": zoning_columns,
+                    "description": """
+                    Unless DCP does a major rezoning, the number of lots with changed values should be **no more than a couple of hundred**.
+                    Lots may get a changed value due to a split/merge or if TRD is cleaning up boundaries between zoning districts.
+                    `Residfar`, `commfar`, and `facilfar` should change only when there is a change to `zonedist1` or `overlay1`.
+                """,
+                },
+                {
+                    "title": "Mismatch graph -- geo",
+                    "columns": geo_columns,
+                    "description": """
+                    These fields are updated from **Geosupport**. Changes should be minimal unless a municipal service
+                    area changes or more high-rise buildings opt into the composite recycling program.
+                    Check with GRU if more than a small number of lots have changes to municipal service areas.
+                """,
+                },
+                {
+                    "title": "Mismatch graph -- building",
+                    "columns": bldg_columns,
+                    "description": """
+                    Changes in these fields are most common in February, after the tentative roll has been released.
+                    Several fields in this group are changed by DCP to improve data quality, including `ownername` and `yearbuilt`.
+                    When these changes are first applied, there will be a spike in the number of lots changed.
+                """,
+                },
+            ]
+
+            df = df_mismatch.loc[
+                (df_mismatch.condo == condo)
+                & (df_mismatch.mapped == mapped)
+                & (df_mismatch.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
+                :,
+            ]
+
+            v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
+            v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
+            v1v2_total = v1v2.pop("total")
+            v2v3_total = v2v3.pop("total")
+
+            def generate_graph_data(r, total, name, group):
+                r = {key: value for (key, value) in r.items() if key in group}
+                y = [r[i] for i in group]
+                x = group
+                hovertemplate = "<b>%{x} %{text}</b>"
+                text = [f"{round(r[i]/total*100, 2)}%" for i in group]
+                return go.Scatter(
+                    x=x,
+                    y=y,
+                    mode="lines",
+                    name=name,
+                    hovertemplate=hovertemplate,
+                    text=text,
+                )
+
+            def generate_graph(v1v2, v2v3, v1v2_total, v2v3_total, group):
+                fig = go.Figure()
+                fig.add_trace(generate_graph_data(v1v2, v1v2_total, v1v2["pair"], group))
+                fig.add_trace(generate_graph_data(v2v3, v2v3_total, v2v3["pair"], group))
+                return fig
+
+            for group in groups:
+                fig = generate_graph(v1v2, v2v3, v1v2_total, v2v3_total, group["columns"])
+                fig.update_layout(title=group["title"], template="plotly_white")
+                st.plotly_chart(fig)
+                st.info(group["description"])
+            st.write(df)
+
+        def create_null(df_null, v1, v2, v3, condo, mapped):
+            df = df_null.loc[
+                (df_null.condo == condo)
+                & (df_null.mapped == mapped)
+                & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
+                :,
+            ]
+            v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :].to_dict("records")[0]
+            v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :].to_dict("records")[0]
+            v1v2_total = v1v2.pop("total")
+            v2v3_total = v2v3.pop("total")
+
+            x = [
+                "borough",
+                "block",
+                "lot",
+                "cd",
+                # "bct2020",
+                # "bctcb2020",
+                "ct2010",
+                "cb2010",
+                "schooldist",
+                "council",
+                "zipcode",
+                "firecomp",
+                "policeprct",
+                "healtharea",
+                "sanitboro",
+                "sanitsub",
+                "address",
+                "zonedist1",
+                "zonedist2",
+                "zonedist3",
+                "zonedist4",
+                "overlay1",
+                "overlay2",
+                "spdist1",
+                "spdist2",
+                "spdist3",
+                "ltdheight",
+                "splitzone",
+                "bldgclass",
+                "landuse",
+                "easements",
+                "ownertype",
+                "ownername",
                 "lotarea",
                 "bldgarea",
                 "comarea",
@@ -423,9 +394,51 @@ def pluto():
                 "strgearea",
                 "factryarea",
                 "otherarea",
+                "areasource",
+                "numbldgs",
+                "numfloors",
+                "unitsres",
+                "unitstotal",
+                "lotfront",
+                "lotdepth",
+                "bldgfront",
+                "bldgdepth",
+                "ext",
+                "proxcode",
+                "irrlotcode",
+                "lottype",
+                "bsmtcode",
                 "assessland",
                 "assesstot",
                 "exempttot",
+                "yearbuilt",
+                "yearalter1",
+                "yearalter2",
+                "histdist",
+                "landmark",
+                "builtfar",
+                "residfar",
+                "commfar",
+                "facilfar",
+                "borocode",
+                "bbl",
+                "condono",
+                "tract2010",
+                "xcoord",
+                "ycoord",
+                "longitude",
+                "latitude",
+                "zonemap",
+                "zmcode",
+                "sanborn",
+                "taxmap",
+                "edesignum",
+                "appbbl",
+                "appdate",
+                "plutomapid",
+                "version",
+                "sanitdistrict",
+                "healthcenterdistrict",
                 "firm07_flag",
                 "pfirm15_flag",
             ]
@@ -472,125 +485,206 @@ def pluto():
         """
         )
 
-    def create_expected(df, v1, v2):
-
-        exp = df[df["v"].isin([v1, v2])]
-
-        exp_records = exp.to_dict("records")
-        v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]
-        v2_exp = [i["expected"] for i in exp_records if i["v"] == v2][0]
-        for field in [
-            "zonedist1",
-            "zonedist2",
-            "zonedist3",
-            "zonedist4",
-            "overlay1",
-            "overlay2",
-            "spdist1",
-            "spdist2",
-            "spdist3",
-            "ext",
-            "proxcode",
-            "irrlotcode",
-            "lottype",
-            "bsmtcode",
-            "bldgclasslanduse",
-        ]:
-            val1 = [i["values"] for i in v1_exp if i["field"] == field][0]
-            val2 = [i["values"] for i in v2_exp if i["field"] == field][0]
-            in1not2 = [i for i in val1 if i not in val2]
-            in2not1 = [i for i in val2 if i not in val1]
-            if len(in1not2) == 0 and len(in2not1) == 0:
-                pass
-            else:
-                st.markdown(f"### Expected value difference for {field}")
-                if len(in1not2) != 0:
-                    st.markdown(f"* in {v1} but not in {v2}:")
-                    st.write(in1not2)
-                if len(in2not1) != 0:
-                    st.markdown(f"* in {v2} but not in {v1}:")
-                    st.write(in2not1)
-
-    def create_corrections_graph(df, version, applied):
-        def title_text(version, applied):
-            applied_text = "Applied Manual Corrections " if applied else "Manual Corrections Not Applied "
-            version_text = "for All Versions by Field" if version == "All" else f"introduced in Version {version} by Field"
-
-            return applied_text + version_text
-            
-        def generate_graph(v1, version, applied):
-            return px.bar(
-                v1, 
-                x='field',
-                 y='size', 
-                 text='size',
-                 title=title_text(version, applied), 
-                 labels={'size': 'Count of Records', 'field': 'Altered Field'}
+            fig = go.Figure()
+            fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
+            fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
+            fig.update_layout(title="Null graph", template="plotly_white")
+            st.plotly_chart(fig)
+            st.write(df)
+            st.info(
+                """
+            The mismatch graphs do not include lots that formerly had a value and are now null, or vice versa.
+            These differences are captured in the null graph, which shows the percent change in lots with a null value.
+            Hovering over a point shows you the number of null records in the more recent file. The number of such changes should be small.
+            """
             )
 
-        def field_correction_counts(df):
-            return df.groupby(['field']).size().to_frame('size').reset_index()
-        
-        def filter_by_version(df, version):
-            if version == 'All':
-                return df
-            else:
-                return df.loc[df['version'] == version]
+        def create_aggregate(df_aggregate, v1, v2, v3, condo, mapped):
+            df = df_aggregate.loc[
+                (df_aggregate.condo == condo)
+                & (df_aggregate.mapped == mapped)
+                & (df_aggregate.v.isin([v1, v2, v3])),
+                :,
+            ]
+            v1 = df.loc[df.v == v1, :].to_dict("records")[0]
+            v2 = df.loc[df.v == v2, :].to_dict("records")[0]
+            v3 = df.loc[df.v == v3, :].to_dict("records")[0]
 
-        def empty_message(applied, version):
-            if applied:
-                st.info(f"No Corrections introduced in Version {version} were applied.")
-            else:
-                st.info(f"All Corrections introduced in Version {version} were applied.")
+            def generate_graph(v1, v2):
+                _v1 = v1["v"]
+                _v2 = v2["v"]
 
-        df = filter_by_version(df, version)
+                y = [
+                    "unitsres",
+                    "lotarea",
+                    "bldgarea",
+                    "comarea",
+                    "resarea",
+                    "officearea",
+                    "retailarea",
+                    "garagearea",
+                    "strgearea",
+                    "factryarea",
+                    "otherarea",
+                    "assessland",
+                    "assesstot",
+                    "exempttot",
+                    "firm07_flag",
+                    "pfirm15_flag",
+                ]
+                x = [(v1[i] / v2[i] - 1) * 100 for i in y]
+                hovertemplate = "<b>%{x} %{text}</b>"
+                return go.Scatter(
+                    x=y,
+                    y=x,
+                    mode="lines",
+                    name=f"{_v1} - {_v2}",
+                    hovertemplate=hovertemplate,
+                    text=[f"{round(i,2)}%" for i in x],
+                )
 
-        if df.empty:
-            empty_message(applied, version)
+            fig = go.Figure()
+            fig.add_trace(generate_graph(v1, v2))
+            fig.add_trace(generate_graph(v2, v3))
+            fig.update_layout(title="Aggregate graph", template="plotly_white")
+            st.plotly_chart(fig)
+            st.write(df)
+            st.info(
+                """
+            In addition to looking at the number of lots with a changed value, it’s important to look at the magnitude of the change.
+            For example, the mismatch graph for finance may show that over 90% of lots get an updated assessment when the tentative roll is released.
+            The aggregate graph may show that the aggregated sum increased by 5%. Totals for assessland, assesstot, and exempttot should only change in February and June.
+            Pay attention to any large changes to residential units (unitsres).
+            """
+            )
+
+        def create_expected(df, v1, v2):
+
+            exp = df[df["v"].isin([v1, v2])]
+
+            exp_records = exp.to_dict("records")
+            v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]
+            v2_exp = [i["expected"] for i in exp_records if i["v"] == v2][0]
+            for field in [
+                "zonedist1",
+                "zonedist2",
+                "zonedist3",
+                "zonedist4",
+                "overlay1",
+                "overlay2",
+                "spdist1",
+                "spdist2",
+                "spdist3",
+                "ext",
+                "proxcode",
+                "irrlotcode",
+                "lottype",
+                "bsmtcode",
+                "bldgclasslanduse",
+            ]:
+                val1 = [i["values"] for i in v1_exp if i["field"] == field][0]
+                val2 = [i["values"] for i in v2_exp if i["field"] == field][0]
+                in1not2 = [i for i in val1 if i not in val2]
+                in2not1 = [i for i in val2 if i not in val1]
+                if len(in1not2) == 0 and len(in2not1) == 0:
+                    pass
+                else:
+                    st.markdown(f"### Expected value difference for {field}")
+                    if len(in1not2) != 0:
+                        st.markdown(f"* in {v1} but not in {v2}:")
+                        st.write(in1not2)
+                    if len(in2not1) != 0:
+                        st.markdown(f"* in {v2} but not in {v1}:")
+                        st.write(in2not1)
+        create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
+
+        create_null(data["df_null"], v1, v2, v3, condo, mapped)
+
+        create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
+
+        st.header("Source Data Versions")
+        code = st.checkbox("code")
+        if code:
+            st.code(data["version_text"])
         else:
-            figure = generate_graph(field_correction_counts(df), version, applied)
-            st.plotly_chart(figure)
+            st.markdown(data["version_text"])
 
-    def corrections_section(applied_corrections, not_applied_corrections):
-        st.header("Manual Corrections")
-
-        version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')
-        version = st.selectbox("Select a Version for which manual corrections were first introduced.", version_dropdown)
-
-        # create_corrections(data["pluto_corrections"], version)
-        create_corrections_graph(applied_corrections, version, applied=True)
-        create_corrections_graph(not_applied_corrections, version, applied=False)
-
-        st.info(
-            """
-            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. 
-            See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
-            in the PLUTO change file.
-            """
+        # EXPECTED VALUE
+        st.header("Expected Value Comparison")
+        st.write(
+            "if nothing showed up, then it means there aren't any expected value change"
         )
 
-    create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
+        create_expected(data["df_expected"], v1, v2)
 
-    create_null(data["df_null"], v1, v2, v3, condo, mapped)
+    def manual_corrections_report(data):
+        def create_corrections_graph(df, version, applied):
+            def title_text(version, applied):
+                applied_text = "Applied Manual Corrections " if applied else "Manual Corrections Not Applied "
+                version_text = "for All Versions by Field" if version == "All" else f"introduced in Version {version} by Field"
 
-    create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
+                return applied_text + version_text
+                
+            def generate_graph(v1, version, applied):
+                return px.bar(
+                    v1, 
+                    x='field',
+                    y='size', 
+                    text='size',
+                    title=title_text(version, applied), 
+                    labels={'size': 'Count of Records', 'field': 'Altered Field'}
+                )
 
-    st.header("Source Data Versions")
-    code = st.checkbox("code")
-    if code:
-        st.code(data["version_text"])
+            def field_correction_counts(df):
+                return df.groupby(['field']).size().to_frame('size').reset_index()
+            
+            def filter_by_version(df, version):
+                if version == 'All':
+                    return df
+                else:
+                    return df.loc[df['version'] == version]
+
+            def empty_message(applied, version):
+                if applied:
+                    st.info(f"No Corrections introduced in Version {version} were applied.")
+                else:
+                    st.info(f"All Corrections introduced in Version {version} were applied.")
+
+            df = filter_by_version(df, version)
+
+            if df.empty:
+                empty_message(applied, version)
+            else:
+                figure = generate_graph(field_correction_counts(df), version, applied)
+                st.plotly_chart(figure)
+
+        def corrections_section(applied_corrections, not_applied_corrections):
+            st.header("Manual Corrections")
+
+            version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')
+            version = st.selectbox("Select a Version for which manual corrections were first introduced.", version_dropdown)
+
+            # create_corrections(data["pluto_corrections"], version)
+            create_corrections_graph(applied_corrections, version, applied=True)
+            create_corrections_graph(not_applied_corrections, version, applied=False)
+
+            st.info(
+                """
+                This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. 
+                See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+                in the PLUTO change file.
+                """
+            )
+
+        corrections_section(
+            applied_corrections=data['pluto_corrections_applied'], 
+            not_applied_corrections=data['pluto_corrections_not_applied']
+        )
+
+    report_type = st.sidebar.selectbox("Choose a Report Type", ["Compare with Previous Version", "Review Manual Corrections"])
+
+    if report_type == 'Compare with Previous Version':
+        version_comparison_report(data)
     else:
-        st.markdown(data["version_text"])
-
-    # EXPECTED VALUE
-    st.header("Expected Value Comparison")
-    st.write(
-        "if nothing showed up, then it means there aren't any expected value change"
-    )
-
-    create_expected(data["df_expected"], v1, v2)
-
-    corrections_section(
-        applied_corrections=data['pluto_corrections_applied'], 
-        not_applied_corrections=data['pluto_corrections_not_applied']
-    )
+        manual_corrections_report(data)
+    

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -27,6 +27,8 @@ def pluto():
 
     data = get_data(branch)
 
+    report_type = st.sidebar.selectbox("Choose a Report Type", ["Compare with Previous Version", "Review Manual Corrections"])
+
     def version_comparison_report(data):
         versions = [
             "22v2",
@@ -631,8 +633,6 @@ def pluto():
             in the PLUTO change file.
             """
         )
-
-    report_type = st.sidebar.selectbox("Choose a Report Type", ["Compare with Previous Version", "Review Manual Corrections"])
 
     if report_type == 'Compare with Previous Version':
         version_comparison_report(data)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -602,7 +602,7 @@ def pluto():
             """
         )
         version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')
-        version = st.selectbox("Filter the field corrections by the PLUTO Version in which they were first introduced", version_dropdown)
+        version = st.sidebar.selectbox("Filter the field corrections by the PLUTO Version in which they were first introduced", version_dropdown)
 
         st.subheader("Manual Corrections Applied", anchor="corrections-applied")
         

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -512,16 +512,6 @@ def pluto():
                     st.write(in2not1)
 
     def create_corrections(df):
-        def generate_trace(v1):
-            hovertemplate = "<b>%{x} - %{y}</b>"
-            return go.Scatter(
-                y=v1,
-                x=v1.index,
-                mode="lines",
-                name="Pluto Corrections",
-                hovertemplate=hovertemplate,
-                text=v1.index
-            )
         def version_title_text(version):
             if version == "All":
                 return "All Versions"

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -587,6 +587,10 @@ def pluto():
         applied_corrections = data['pluto_corrections_applied']
         not_applied_corrections = data['pluto_corrections_not_applied']
 
+        if applied_corrections is None or not_applied_corrections is None:
+            st.info("There are no available corrections reports for this branch.")
+            return
+            
         st.markdown(
             """
             PLUTO is created using the best available data from a number of city agencies. To further
@@ -601,9 +605,10 @@ def pluto():
             see the [Pluto Changelog Readme](https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/pluto_change_file_readme.pdf?r=22v1).
             """
         )
+
         version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')
         version = st.sidebar.selectbox("Filter the field corrections by the PLUTO Version in which they were first introduced", version_dropdown)
-
+        
         st.subheader("Manual Corrections Applied", anchor="corrections-applied")
         
         create_corrections_section(applied_corrections, version, applied=True)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -4,6 +4,7 @@ def pluto():
     import numpy as np
     from sqlalchemy import create_engine
     import plotly.graph_objects as go
+    import plotly.express as px
     import os
     from datetime import datetime
     import requests
@@ -601,7 +602,7 @@ def pluto():
             """
         )
         version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')
-        version = st.selectbox("Filter the field corrections by PLUTO Version introduced", version_dropdown)
+        version = st.selectbox("Filter the field corrections by the PLUTO Version in which they were first introduced", version_dropdown)
 
         st.subheader("Manual Corrections Applied", anchor="corrections-applied")
         

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -626,7 +626,7 @@ def pluto():
         not_applied_corrections = data['pluto_corrections_not_applied']
 
         if applied_corrections is None or not_applied_corrections is None:
-            st.info("There are no available corrections reports for this branch.")
+            st.info("There are no available corrections reports for this branch. This is likely due to a problem on the backend with the files on Digital Ocean.")
             return
             
         version_dropdown = np.insert(np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())), 0, 'All')

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -536,6 +536,12 @@ def pluto():
         
         st.header("Corrections")
         st.plotly_chart(figure)
+        st.info(
+            """
+            This report shows the number of records altered by DCP to correct errors in the underlying data, grouped by the field altered. See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+            in the PLUTO change file.
+            """
+        )
 
     create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -510,6 +510,33 @@ def pluto():
                     st.markdown(f"* in {v2} but not in {v1}:")
                     st.write(in2not1)
 
+    def create_corrections(df):
+        def generate_trace(v1):
+            hovertemplate = "<b>%{x} - %{y}</b>"
+            return go.Scatter(
+                y=v1,
+                x=v1.index,
+                mode="lines",
+                name="Pluto Corrections",
+                hovertemplate=hovertemplate,
+                text=v1.index
+            )
+        def generate_graph(v1):
+            fig = go.Figure()
+            fig.add_trace(generate_trace(v1))
+            fig.update_yaxes(title_text="# of Corrected Records")
+            fig.update_xaxes(title_text="Field")
+            fig.update_layout(title="Corrected Records by Field", template="plotly_white")
+            return fig
+
+        def field_correction_counts(df):
+            return df.groupby(['field']).size()
+        
+        figure = generate_graph(field_correction_counts(df))
+        
+        st.header("Corrections")
+        st.plotly_chart(figure)
+
     create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 
     create_null(data["df_null"], v1, v2, v3, condo, mapped)
@@ -530,3 +557,6 @@ def pluto():
     )
 
     create_expected(data["df_expected"], v1, v2)
+
+    create_corrections(data["pluto_corrections"])
+


### PR DESCRIPTION
There are alot of changes in this PR that are just moving the existing pluto versions reports into a function to facilitate a seperate page for the Manual Corrections. The additions to pluto.py are at the bottom in the manual_corrections_report function.

This PR is blocked by getting the manual corrections applied and not applied reports pushed from PLUTO.

1. New Page for Manual Corrections shows graphs by field for corrections applied and not applied.
Includes Dropdown to filter by Version or all Records.
2. Incorporates Language from our existing readme for pluto corrections
3. Follows FACDB architecture for two different pages on the same app - I wonder if we don't want to decouple these even more in the future and create new seperate component files. I find all of the nested function stuff hard to follow, but I tried to structure this code so that they could easily be refactored in the future.

