### PR TITLE
handle exception for pre-22v2 outlier

### DIFF
--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -525,6 +525,10 @@ def pluto():
                         st.write(in2not1)
 
         def create_outlier(df, v1, v2, condo, mapped):
+            if v1 !='22v2':
+                st.write('There is no outlier report available for selected version.')
+                return 
+                
             outlier = df.loc[
                 (df.condo == condo) & (df.mapped == mapped) & (df.v == v1),
                 :,

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -525,15 +525,15 @@ def pluto():
                         st.write(in2not1)
 
         def create_outlier(df, v1, v2, condo, mapped):
-            if v1 !='22v2':
-                st.write('There is no outlier report available for selected version.')
-                return 
-                
+            versions = df.v.unique()
+            if v1 not in versions:
+                st.write("There is no outlier report available for selected version.")
+                return
+
             outlier = df.loc[
                 (df.condo == condo) & (df.mapped == mapped) & (df.v == v1),
                 :,
             ]
-
             outlier_records = outlier.to_dict("records")
             v1_outlier = [i["outlier"] for i in outlier_records if i["v"] == v1][0]
 


### PR DESCRIPTION
display the message saying there is no outlier report available if the user select any version before 22v2 instead of showing the error