### PR TITLE
Fix bug for PLUTO null graphs and delete duplicates in tables

### DIFF
--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -284,11 +284,20 @@ def pluto():
                 & (df_null.mapped == mapped)
                 & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
                 :,
-            ]
-            v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-            v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :].to_dict("records")[0]
-            v1v2_total = v1v2.pop("total")
-            v2v3_total = v2v3.pop("total")
+            ].drop_duplicates()
+
+            v1v2_exist=True
+            v2v3_exist=True
+            try:
+                v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :].to_dict("records")[0]
+                v1v2_total = v1v2.pop("total")
+            except:
+                v1v2_exist=False
+            try:
+                v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :].to_dict("records")[0]
+                v2v3_total = v2v3.pop("total")
+            except:
+                v2v3_exist=False
 
             x = [
                 "borough",
@@ -396,8 +405,12 @@ def pluto():
                 )
 
             fig = go.Figure()
-            fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
-            fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
+            if not v1v2_exist and not v2v3_exist:
+                return
+            if v1v2_exist:
+                fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
+            if v2v3_exist:
+                fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
             fig.update_layout(title="Null graph", template="plotly_white")
             st.plotly_chart(fig)
             st.write(df)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -279,26 +279,6 @@ def pluto():
             st.write(df)
 
         def create_null(df_null, v1, v2, v3, condo, mapped):
-            df = df_null.loc[
-                (df_null.condo == condo)
-                & (df_null.mapped == mapped)
-                & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
-                :,
-            ].drop_duplicates()
-
-            v1v2_exist=True
-            v2v3_exist=True
-            try:
-                v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-                v1v2_total = v1v2.pop("total")
-            except:
-                v1v2_exist=False
-            try:
-                v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :].to_dict("records")[0]
-                v2v3_total = v2v3.pop("total")
-            except:
-                v2v3_exist=False
-
             x = [
                 "borough",
                 "block",
@@ -404,13 +384,30 @@ def pluto():
                     text=text,
                 )
 
+            df = df_null.loc[
+                (df_null.condo == condo)
+                & (df_null.mapped == mapped)
+                & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
+                :,
+            ].drop_duplicates()
+
+            v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :]
+            v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :]
+
             fig = go.Figure()
-            if not v1v2_exist and not v2v3_exist:
+            if v1v2.empty and v2v3.empty:
+                st.write("Null Graph")
+                st.info("There is no change in NULL values across three versions.")
                 return
-            if v1v2_exist:
+            if not v1v2.empty:
+                v1v2 = v1v2.to_dict("records")[0]
+                v1v2_total = v1v2.pop("total")
                 fig.add_trace(generate_graph(v1v2, v1v2_total, f"{v1} - {v2}"))
-            if v2v3_exist:
+            if not v2v3.empty:
+                v2v3 = v2v3.to_dict("records")[0]
+                v2v3_total = v2v3.pop("total")
                 fig.add_trace(generate_graph(v2v3, v2v3_total, f"{v2} - {v3}"))
+
             fig.update_layout(title="Null graph", template="plotly_white")
             st.plotly_chart(fig)
             st.write(df)


### PR DESCRIPTION
In some previous versions of PLUTO, the page will throw list index out of range error in the null graph section. Also, seems like there are duplicate records in previous versions which are not deleted in the qaqc exporting step. Made some adjustments to the current code to handle the exception (no null mismatch record for selected version) and deleted duplicates in the displayed table. 
One thing not sure about is whether we display a message saying "There is no null value changes between 2 versions" or we can just skip this part if nothing is fetched. 