### PR TITLE
Remove last two  versions from dropdown

### DIFF
--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -54,7 +54,7 @@ def pluto():
 
         v1 = st.sidebar.selectbox(
             "Pick a version of PLUTO:",
-            versions,  # index=len(versions) - 1
+            versions[:-2],  # Can't produce comparison report for last two versions
         )
 
         v2 = versions[versions.index(v1) + 1]
@@ -160,6 +160,12 @@ def pluto():
                 "firm07_flag",
                 "pfirm15_flag",
             ]
+            ab = ["a", "b", "c"]
+            av = ["a", "b", "c"]
+
+            ac = ["a", "b", "c"]
+
+            ad = ["a", "b", "c"]
 
             bldg_columns = [
                 "bldgclass",


### PR DESCRIPTION
Addresses #109 

Because Pluto QAQC is a comparison between the chosen version and the previous two versions, choosing one of the earliest two versions available causes an index out of bounds error. This removes the ability to select them, but leaves them in the array so that they can be compared if you choose the third-to-last version.