### PR TITLE
Cache Blog Posts

### DIFF
--- a/src/home.py
+++ b/src/home.py
@@ -2,14 +2,8 @@ import requests
 import datetime
 import streamlit as st
 
-
-def get_blogs():
-    r = requests.get(
-        "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/nyc-planning-digital/tagged/data-engineering"
-    )
-    result = r.json()["items"]
-
-    css = """
+BLOG_URL = "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/nyc-planning-digital/tagged/data-engineering"
+CSS = """
         .blog-card {
         box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
         transition: 0.3s;
@@ -32,17 +26,27 @@ def get_blogs():
         padding: 2px 16px;
         }
     """
-    for i in result:
+
+
+@st.cache(ttl=30000)
+def retrieve_blog_posts():
+    return requests.get(
+        "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/nyc-planning-digital/tagged/data-engineering"
+    ).json()["items"]
+
+
+def get_blogs():
+    for post in retrieve_blog_posts():
         st.markdown(
             f"""
         <style>
-        {css}
+        {CSS}
         </style>
         <div class="blog-card">
-        <img src="{i['thumbnail']}" alt="Avatar" style="width:100%;">
+        <img src="{post['thumbnail']}" alt="Avatar" style="width:100%;">
             <div class="container">
-                <a href="{i['link']}"><h4><b>{i['title']}</b></h4></a>
-                <p>By {i['author']}</p>
+                <a href="{post['link']}"><h4><b>{post['title']}</b></h4></a>
+                <p>By {post['author']}</p>
             </div>
         </div>
         """,

--- a/src/home.py
+++ b/src/home.py
@@ -35,7 +35,7 @@ def retrieve_blog_posts():
     ).json()["items"]
 
 
-def get_blogs():
+def display_blog():
     for post in retrieve_blog_posts():
         st.markdown(
             f"""
@@ -75,4 +75,4 @@ def home():
     )
 
     st.header("Read more on Medium")
-    get_blogs()
+    display_blog()

--- a/src/home.py
+++ b/src/home.py
@@ -30,9 +30,7 @@ CSS = """
 
 @st.cache(ttl=30000)
 def retrieve_blog_posts():
-    return requests.get(
-        "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/nyc-planning-digital/tagged/data-engineering"
-    ).json()["items"]
+    return requests.get(BLOG_URL).json()["items"]
 
 
 def display_blog():


### PR DESCRIPTION
Addresses #122 
Realized after merging #111 that loading the blogs was a bit time consuming and could potentially slow loading the app. Add in caching like -> https://docs.streamlit.io/library/api-reference/performance/st.cache to speed things up. It will cache for all users for a few hours.