### PR TITLE
Moved Corrections Report into Component

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         "plotly",
         "python-dotenv",
         "boto3",
-        "streamlit-aggrid"
+        "streamlit-aggrid",
+        "python-abc",
     ],
     zip_safe=False,
 )

--- a/src/pluto/components/corrections_report.py
+++ b/src/pluto/components/corrections_report.py
@@ -1,0 +1,133 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+from st_aggrid import AgGrid
+from src.constants import COLOR_SCHEME
+
+
+def corrections_report(data):
+    st.header("Manual Corrections")
+
+    st.markdown(
+        """
+        PLUTO is created using the best available data from a number of city agencies. To further
+        improve data quality, the Department of City Planning (DCP) applies changes to selected field
+        values.
+
+        Each Field Correction is labeled for a version of PLUTO. For programmatic changes, this is version in which the programmatic change was
+        implemented. For research and user reported changes, this is the version in which the BBL
+        change was added to PLUTO_input_research.csv.
+
+        For more information about the structure of the pluto corrections report,
+        see the [Pluto Changelog Readme](https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/pluto_change_file_readme.pdf?r=22v1).
+        """
+    )
+
+    applied_corrections = data["pluto_corrections_applied"]
+    not_applied_corrections = data["pluto_corrections_not_applied"]
+
+    if applied_corrections is None or not_applied_corrections is None:
+        st.info(
+            "There are no available corrections reports for this branch. This is likely due to a problem on the backend with the files on Digital Ocean."
+        )
+        return
+
+    version_dropdown = np.insert(
+        np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())),
+        0,
+        "All",
+    )
+    version = st.sidebar.selectbox(
+        "Filter the field corrections by the PLUTO Version in which they were first introduced",
+        version_dropdown,
+    )
+
+    applied_corrections_section(applied_corrections, version)
+    not_applied_corrections_section(not_applied_corrections, version)
+
+    st.info(
+        """
+        See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
+        in the PLUTO change file.
+        """
+    )
+
+
+def applied_corrections_section(corrections, version):
+    st.subheader("Manual Corrections Applied", anchor="corrections-applied")
+    st.markdown(
+        """
+        For each record in the PLUTO Corrections table, PLUTO attempts to change a record to the New Value column by matching on the BBL and the 
+        Old Value column. The graph and table below outline the records in the pluto corrections table that were successfully applied to PLUTO.
+        """
+    )
+    corrections = filter_by_version(corrections, version)
+
+    if corrections.empty:
+        st.info(f"No Corrections introduced in {version_text(version)} were applied.")
+    else:
+        title_text = (
+            f"Applied Manual Corrections introduced in {version_text(version)} by Field"
+        )
+        display_corrections_figures(corrections, title_text)
+
+
+def not_applied_corrections_section(corrections, version):
+    st.subheader("Manual Corrections Not Applied", anchor="corrections-not-applied")
+    st.markdown(
+        """ 
+        For each record in the PLUTO Corrections table, PLUTO attempts to correct a record by matching on the BBL and the 
+        Old Value column. As the underlying datasources change and improve, PLUTO records may no longer match the old value 
+        specified in the pluto corrections table. The graph and table below outline the records in the pluto corrections table that failed to be applied for this reason.
+        """
+    )
+    corrections = filter_by_version(corrections, version)
+
+    if corrections.empty:
+        st.info(f"All Corrections introduced in {version_text(version)} were applied.")
+    else:
+        title_text = f"Manual Corrections not Applied introduced in {version_text(version)} by Field"
+        display_corrections_figures(corrections, title_text)
+
+
+def filter_by_version(df, version):
+    if version == "All":
+        return df
+    else:
+        return df.loc[df["version"] == version]
+
+
+def version_text(version):
+    return "All Versions" if version == "All" else f"Version {version}"
+
+
+def display_corrections_figures(df, title):
+    figure = generate_graph(field_correction_counts(df), title)
+    st.plotly_chart(figure)
+
+    display_corrections_df(df)
+
+
+def generate_graph(corrections, title):
+    return px.bar(
+        corrections,
+        x="field",
+        y="size",
+        text="size",
+        title=title,
+        labels={"size": "Count of Records", "field": "Altered Field"},
+        color_discrete_sequence=COLOR_SCHEME,
+    )
+
+
+def display_corrections_df(corrections):
+    corrections = corrections.sort_values(
+        by=["version", "reason", "bbl"], ascending=[False, True, True]
+    )
+
+    AgGrid(corrections)
+
+
+def field_correction_counts(df):
+    return df.groupby(["field"]).size().to_frame("size").reset_index()

--- a/src/pluto/components/corrections_report.py
+++ b/src/pluto/components/corrections_report.py
@@ -101,10 +101,6 @@ class CorrectionsSection(ABC):
 
 
 class AppliedCorrectionsSection(CorrectionsSection):
-    def __init__(self, corrections, version) -> None:
-        self.corrections = self.filter_by_version(corrections, version)
-        self.version_text = self.version_text(version)
-
     def __call__(self):
         st.subheader("Manual Corrections Applied", anchor="corrections-applied")
 

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -11,6 +11,7 @@ def pluto():
     from src.pluto.helpers import get_branches, get_data
     from st_aggrid import AgGrid
     from src.constants import COLOR_SCHEME
+    from src.pluto.components.corrections_report import corrections_report
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -628,130 +629,7 @@ def pluto():
         st.header("OUTLIER ANALYSIS")
         create_outlier(data["df_outlier"], v1, v2, condo, mapped)
 
-    def manual_corrections_report(data):
-        def filter_by_version(df, version):
-            if version == "All":
-                return df
-            else:
-                return df.loc[df["version"] == version]
-
-        def version_text(version):
-            return "All Versions" if version == "All" else f"Version {version}"
-
-        def display_corrections_figures(df, title):
-            def generate_graph(v1, title):
-                return px.bar(
-                    v1,
-                    x="field",
-                    y="size",
-                    text="size",
-                    title=title,
-                    labels={"size": "Count of Records", "field": "Altered Field"},
-                    color_discrete_sequence=COLOR_SCHEME,
-                )
-
-            def display_corrections_df(corrections):
-                corrections = corrections.sort_values(
-                    by=["version", "reason", "bbl"], ascending=[False, True, True]
-                )
-
-                AgGrid(corrections)
-
-            def field_correction_counts(df):
-                return df.groupby(["field"]).size().to_frame("size").reset_index()
-
-            figure = generate_graph(field_correction_counts(df), title)
-            st.plotly_chart(figure)
-
-            display_corrections_df(df)
-
-        def applied_corrections_section(corrections, version):
-            st.subheader("Manual Corrections Applied", anchor="corrections-applied")
-            st.markdown(
-                """
-                For each record in the PLUTO Corrections table, PLUTO attempts to change a record to the New Value column by matching on the BBL and the 
-                Old Value column. The graph and table below outline the records in the pluto corrections table that were successfully applied to PLUTO.
-                """
-            )
-            corrections = filter_by_version(corrections, version)
-
-            if corrections.empty:
-                st.info(
-                    f"No Corrections introduced in {version_text(version)} were applied."
-                )
-            else:
-                title_text = f"Applied Manual Corrections introduced in {version_text(version)} by Field"
-                display_corrections_figures(corrections, title_text)
-
-        def not_applied_corrections_section(corrections, version):
-
-            st.subheader(
-                "Manual Corrections Not Applied", anchor="corrections-not-applied"
-            )
-            st.markdown(
-                """ 
-                For each record in the PLUTO Corrections table, PLUTO attempts to correct a record by matching on the BBL and the 
-                Old Value column. As the underlying datasources change and improve, PLUTO records may no longer match the old value 
-                specified in the pluto corrections table. The graph and table below outline the records in the pluto corrections table that failed to be applied for this reason.
-                """
-            )
-            corrections = filter_by_version(corrections, version)
-
-            if corrections.empty:
-                st.info(
-                    f"All Corrections introduced in {version_text(version)} were applied."
-                )
-            else:
-                title_text = f"Manual Corrections not Applied introduced in {version_text(version)} by Field"
-                display_corrections_figures(corrections, title_text)
-
-        st.header("Manual Corrections")
-
-        st.markdown(
-            """
-            PLUTO is created using the best available data from a number of city agencies. To further
-            improve data quality, the Department of City Planning (DCP) applies changes to selected field
-            values.
-
-            Each Field Correction is labeled for a version of PLUTO. For programmatic changes, this is version in which the programmatic change was
-            implemented. For research and user reported changes, this is the version in which the BBL
-            change was added to PLUTO_input_research.csv.
-
-            For more information about the structure of the pluto corrections report,
-            see the [Pluto Changelog Readme](https://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/pluto_change_file_readme.pdf?r=22v1).
-            """
-        )
-
-        applied_corrections = data["pluto_corrections_applied"]
-        not_applied_corrections = data["pluto_corrections_not_applied"]
-
-        if applied_corrections is None or not_applied_corrections is None:
-            st.info(
-                "There are no available corrections reports for this branch. This is likely due to a problem on the backend with the files on Digital Ocean."
-            )
-            return
-
-        version_dropdown = np.insert(
-            np.flip(np.sort(data["pluto_corrections"].version.dropna().unique())),
-            0,
-            "All",
-        )
-        version = st.sidebar.selectbox(
-            "Filter the field corrections by the PLUTO Version in which they were first introduced",
-            version_dropdown,
-        )
-
-        applied_corrections_section(applied_corrections, version)
-        not_applied_corrections_section(not_applied_corrections, version)
-
-        st.info(
-            """
-            See [here](https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page) for a full accounting of the changes made for the latest version
-            in the PLUTO change file.
-            """
-        )
-
     if report_type == "Compare with Previous Version":
         version_comparison_report(data)
     elif report_type == "Review Manual Corrections":
-        manual_corrections_report(data)
+        corrections_report(data)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -11,7 +11,7 @@ def pluto():
     from src.pluto.helpers import get_branches, get_data
     from st_aggrid import AgGrid
     from src.constants import COLOR_SCHEME
-    from src.pluto.components.corrections_report import corrections_report
+    from src.pluto.components.corrections_report import CorrectionsReport
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -632,4 +632,4 @@ def pluto():
     if report_type == "Compare with Previous Version":
         version_comparison_report(data)
     elif report_type == "Review Manual Corrections":
-        corrections_report(data)
+        CorrectionsReport(data)()


### PR DESCRIPTION
Addresses #124 
There are no real code changes here, other than:
1. Creates new component folder, and a new corrections_report.py file to encapsulate all corrections related code
2. Moves all functions in the corrections report out of their nesting, which is easier for testing, ipython, etc.

Some decisions we might answer here, or in a future PR:
1. How should data ingestion work?
2. How should importing components work?
3. How should importing libraries work? Is there any way to avoid doing that for every file?
4. Should a component be a class instead of just a group of functions?

Figured I'd get the ball rolling though with minimal extra changes. Maybe 2 🐰 reviewers to approve of the architectural change