### PR TITLE
Sort PLUTO aggregate table by latest version 

### DIFF
--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -505,7 +505,7 @@ def pluto():
                 colorway=COLOR_SCHEME,
             )
             st.plotly_chart(fig)
-            st.write(df)
+            st.write(df.sort_values(by="v", ascending=False))
             st.info(
                 """
                 In addition to looking at the number of lots with a changed value, it’s important to look at the magnitude of the change. 


### PR DESCRIPTION
The table under the aggregate graph didn't order the versions of PLUTO for an easy comparison. This PR addresses reordering them in the table so that the latest version is first, previous version second, etc...