### PR TITLE
Catch file not found error

### DIFF
--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -1,5 +1,7 @@
 import pandas as pd
 from typing import Dict
+from urllib.error import HTTPError
+import streamlit as st
 
 BUCKET_NAME = "edm-publishing"
 
@@ -16,4 +18,7 @@ def get_data(branch):
 
 
 def csv_from_DO(url, kwargs={}):
-    return pd.read_csv(url, **kwargs)
+    try:
+        return pd.read_csv(url, **kwargs)
+    except HTTPError:
+        st.warning(f"{url} not found")


### PR DESCRIPTION
This change could have been incorporated into PR #154 but I didn't get a chance to review before it got merged. This won't prevent errors downstream when the file isn't found, we should implement similar warnings in the appropriate sections 