### PR TITLE
DevDB manual corrections reports

### DIFF
--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -1,4 +1,3 @@
-from re import M
 import pandas as pd
 from typing import Dict
 from urllib.error import HTTPError

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -167,7 +167,6 @@ QAQC_CHECK_DICTIONARY = {
     }
 }
 
-@st.cache(ttl=600)
 def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -168,7 +168,7 @@ QAQC_CHECK_DICTIONARY = {
     }
 }
 
-@st.cache
+@st.cache(ttl=600)
 def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -1,3 +1,4 @@
+from re import M
 import pandas as pd
 from typing import Dict
 from urllib.error import HTTPError
@@ -155,9 +156,19 @@ QAQC_CHECK_DICTIONARY = {
         "field_type": "boolean",
         "section": "n/a",
     },
+    "manual_hny_match_check": {
+        "description": "check if the manual HNY corrections are ingested and any HNY projects failed to be added will show up here",
+        "field_type": "boolean",
+        "section": "n/a",
+    },
+    "manual_corrections_not_applied": {
+        "description": "This will return the full list of jobs that have any manual corrections did not get applied.",
+        "field_type": "boolean",
+        "section": "n/a"
+    }
 }
 
-
+@st.cache
 def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"


### PR DESCRIPTION
#147 One reviewer 

Add two very simple checks for manual corrections for devdb page. The detailed of how those checks are created in devdb and their purpose can be read [here](https://github.com/NYCPlanning/db-developments/pull/536). 

Also added `st.cache` to avoid repeated data loading to slow down the toggle between different options. 
