### PR TITLE
Add report on count of records by agency and use type

### DIFF
--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -5,9 +5,16 @@ def colp():
     import os
     import pdb
     from src.colp.helpers import get_data
+    from src.colp.components.agency_usetype_report import (
+        RecordsByAgency,
+        RecordsByUsetype,
+        RecordsByAgencyUsetype,
+    )
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox("select a branch", ["main"])
+    branch = st.sidebar.selectbox(
+        "select a branch", ["main", "212-Records-by-Agency-Usetype"]
+    )
     st.markdown(
         body="""
         ### About COLP Database
@@ -22,3 +29,9 @@ def colp():
     )
 
     data = get_data(branch)
+
+    RecordsByAgency(records_by_agency=data["records_by_agency"])()
+    RecordsByUsetype(records_by_usetype=data["records_by_usetype"])()
+    RecordsByAgencyUsetype(
+        records_by_agency_usetype=data["records_by_agency_usetype"]
+    )()

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -7,7 +7,7 @@ import plotly.express as px
 class CountRecordsReport(ABC):
     def __call__(self):
         if self.data is None:
-            st.info(f"No Count of records by {self.x_axis_col}")
+            st.info(f"No Count of records by {self.y_axis_col}")
             return
         self.set_title()
         self.plot()
@@ -35,14 +35,17 @@ class CountRecordsReport(ABC):
         fig1 = px.bar(
             self.data.iloc[
                 :x_lim,
-            ],
-            x=self.x_axis_col,
-            y="count",
-            width=1000,
+            ].sort_values(by="count", ascending=True),
+            y=self.y_axis_col,
+            x="count",
+            orientation="h",
+            barmode="group",
+            width=850,
+            height=500,
             color_discrete_sequence=COLOR_SCHEME,
         )
 
-        fig1.update_xaxes(title=self.x_axis_col[0] + self.x_axis_col[1:].lower())
+        fig1.update_yaxes(title=self.y_axis_label)
         fig1.update_layout(legend_title_text="Count")
 
         st.plotly_chart(fig1)
@@ -52,7 +55,8 @@ class RecordsByAgency(CountRecordsReport):
     def __init__(self, records_by_agency) -> None:
         self.data = records_by_agency
         self.by_agency = True
-        self.x_axis_col = "AGENCY"
+        self.y_axis_col = "AGENCY"
+        self.y_axis_label = "Agency"
         self.by_usetype = False
         self.category_plural = "Agencies"
 
@@ -61,7 +65,8 @@ class RecordsByUsetype(CountRecordsReport):
     def __init__(self, records_by_usetype) -> None:
         self.data = records_by_usetype
         self.by_agency = False
-        self.x_axis_col = "USETYPE"
+        self.y_axis_col = "USETYPE"
+        self.y_axis_label = "Use type"
         self.by_usetype = True
         self.category_plural = "Use types"
 
@@ -70,9 +75,10 @@ class RecordsByAgencyUsetype(CountRecordsReport):
     def __init__(self, records_by_agency_usetype) -> None:
         self.data = records_by_agency_usetype
         self.data["agency-use type"] = (
-            self.data["AGENCY"] + " - " + self.data["USETYPE"]
+            self.data["AGENCY"] + " - " + self.data["USETYPE"].str.replace("-", "/")
         )
         self.by_agency = True
-        self.x_axis_col = "agency-use type"
+        self.y_axis_col = "agency-use type"
+        self.y_axis_label = "Agency/use type combination"
         self.by_usetype = True
         self.category_plural = "Agency-use type combinations"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -9,20 +9,8 @@ class CountRecordsReport(ABC):
         if self.data is None:
             st.info(f"No Count of records by {self.y_axis_col}")
             return
-        self.set_title()
+        st.subheader(self.title, anchor=self.title_anchor)
         self.plot()
-
-    def set_title(self):
-        by_agency = ""
-        middle_str = ""
-        by_usetype = ""
-        by_agency = "agency" if self.by_agency else ""
-        by_usetype = " use type" if self.by_usetype else ""
-        middle_str = " and" if self.by_agency and self.by_usetype else ""
-        st.subheader(
-            f"City owned and leased properties by {by_agency}{middle_str}{by_usetype}",
-            anchor="corrections-applied",
-        )
 
     def plot(self):
         slider_input = st.select_slider(
@@ -57,7 +45,9 @@ class RecordsByAgency(CountRecordsReport):
         self.y_axis_col = "AGENCY"
         self.y_axis_label = "Agency"
         self.by_usetype = False
-        self.category_plural = "Agencies"
+        self.category_plural = "agencies"
+        self.title = "City owned and leased properties by agency"
+        self.title_anchor = "count_by_agency"
 
 
 class RecordsByUsetype(CountRecordsReport):
@@ -67,7 +57,9 @@ class RecordsByUsetype(CountRecordsReport):
         self.y_axis_col = "USETYPE"
         self.y_axis_label = "Use type"
         self.by_usetype = True
-        self.category_plural = "Use types"
+        self.category_plural = "use types"
+        self.title = "City owned and leased properties by usetype"
+        self.title_anchor = "count_by_usetype"
 
 
 class RecordsByAgencyUsetype(CountRecordsReport):
@@ -80,4 +72,6 @@ class RecordsByAgencyUsetype(CountRecordsReport):
         self.y_axis_col = "agency-use type"
         self.y_axis_label = "Agency/use type combination"
         self.by_usetype = True
-        self.category_plural = "Agency-use type combinations"
+        self.category_plural = "agency/use type combinations"
+        self.title = "City owned and leased properties by agency and usetype"
+        self.title_anchor = "count_by_agency_usetype"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -9,6 +9,10 @@ class CountRecordsReport(ABC):
         if self.data is None:
             st.info(f"No Count of records by {self.x_axis_col}")
             return
+        self.set_title()
+        self.plot()
+
+    def set_title(self):
         by_agency = ""
         middle_str = ""
         by_usetype = ""
@@ -19,7 +23,6 @@ class CountRecordsReport(ABC):
             f"City owned and leased properties by {by_agency}{middle_str}{by_usetype}",
             anchor="corrections-applied",
         )
-        self.plot()
 
     def plot(self):
         x_lim = st.number_input(

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -69,8 +69,10 @@ class RecordsByUsetype(CountRecordsReport):
 class RecordsByAgencyUsetype(CountRecordsReport):
     def __init__(self, records_by_agency_usetype) -> None:
         self.data = records_by_agency_usetype
-        self.data["AGENCY-USETYPE"] = self.data["AGENCY"] + "-" + self.data["USETYPE"]
+        self.data["agency-use type"] = (
+            self.data["AGENCY"] + " - " + self.data["USETYPE"]
+        )
         self.by_agency = True
-        self.X_axis_col = "AGENCY-USETYPE"
+        self.X_axis_col = "agency-use type"
         self.by_usetype = True
         self.category_plural = "Agency-use type combinations"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -1,0 +1,76 @@
+import streamlit as st
+from src.constants import COLOR_SCHEME
+from abc import ABC
+import plotly.express as px
+
+
+class CountRecordsReport(ABC):
+    def __call__(self):
+        if self.data is None:
+            st.info(f"No Count of records by {self.X_axis_col}")
+            return
+        by_agency = ""
+        middle_str = ""
+        by_usetype = ""
+        if self.by_agency:
+            by_agency = " agency"
+        if self.by_usetype:
+            by_usetype = " use type"
+        if self.by_agency and self.by_usetype:
+            middle_str = " and"
+        st.subheader(
+            f"City owned and leased properties by {by_agency}{middle_str}{by_usetype}",
+            anchor="corrections-applied",
+        )
+        self.plot()
+
+    def plot(self):
+        x_lim = st.number_input(
+            label=f"{self.category_plural} to visualize",
+            min_value=2,
+            max_value=self.data.shape[0],
+            value=12,
+        )
+        self.data.sort_values(by="count", ascending=False, inplace=True)
+        fig1 = px.bar(
+            self.data.iloc[
+                :x_lim,
+            ],
+            x=self.X_axis_col,
+            y="count",
+            width=1000,
+            color_discrete_sequence=COLOR_SCHEME,
+        )
+
+        fig1.update_xaxes(title=self.X_axis_col[0] + self.X_axis_col[1:].lower())
+        fig1.update_layout(legend_title_text="Count")
+
+        st.plotly_chart(fig1)
+
+
+class RecordsByAgency(CountRecordsReport):
+    def __init__(self, records_by_agency) -> None:
+        self.data = records_by_agency
+        self.by_agency = True
+        self.X_axis_col = "AGENCY"
+        self.by_usetype = False
+        self.category_plural = "Agencies"
+
+
+class RecordsByUsetype(CountRecordsReport):
+    def __init__(self, records_by_usetype) -> None:
+        self.data = records_by_usetype
+        self.by_agency = False
+        self.X_axis_col = "USETYPE"
+        self.by_usetype = True
+        self.category_plural = "Use types"
+
+
+class RecordsByAgencyUsetype(CountRecordsReport):
+    def __init__(self, records_by_agency_usetype) -> None:
+        self.data = records_by_agency_usetype
+        self.data["AGENCY-USETYPE"] = self.data["AGENCY"] + "-" + self.data["USETYPE"]
+        self.by_agency = True
+        self.X_axis_col = "AGENCY-USETYPE"
+        self.by_usetype = True
+        self.category_plural = "Agency-use type combinations"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -12,12 +12,9 @@ class CountRecordsReport(ABC):
         by_agency = ""
         middle_str = ""
         by_usetype = ""
-        if self.by_agency:
-            by_agency = " agency"
-        if self.by_usetype:
-            by_usetype = " use type"
-        if self.by_agency and self.by_usetype:
-            middle_str = " and"
+        by_agency = "agency" if self.by_agency else ""
+        by_usetype = " use type" if self.by_usetype else ""
+        middle_str = " and" if self.by_agency and self.by_usetype else ""
         st.subheader(
             f"City owned and leased properties by {by_agency}{middle_str}{by_usetype}",
             anchor="corrections-applied",

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -21,7 +21,7 @@ class CountRecordsReport(ABC):
         self.data.sort_values(by="count", ascending=False, inplace=True)
         fig1 = px.bar(
             self.data.iloc[
-                slider_input[0] : slider_input[1],
+                slider_input[0] - 1 : slider_input[1],
             ].sort_values(by="count", ascending=True),
             y=self.y_axis_col,
             x="count",
@@ -41,10 +41,8 @@ class CountRecordsReport(ABC):
 class RecordsByAgency(CountRecordsReport):
     def __init__(self, records_by_agency) -> None:
         self.data = records_by_agency
-        self.by_agency = True
         self.y_axis_col = "AGENCY"
         self.y_axis_label = "Agency"
-        self.by_usetype = False
         self.category_plural = "agencies"
         self.title = "City owned and leased properties by agency"
         self.title_anchor = "count_by_agency"
@@ -53,10 +51,8 @@ class RecordsByAgency(CountRecordsReport):
 class RecordsByUsetype(CountRecordsReport):
     def __init__(self, records_by_usetype) -> None:
         self.data = records_by_usetype
-        self.by_agency = False
         self.y_axis_col = "USETYPE"
         self.y_axis_label = "Use type"
-        self.by_usetype = True
         self.category_plural = "use types"
         self.title = "City owned and leased properties by usetype"
         self.title_anchor = "count_by_usetype"
@@ -68,10 +64,8 @@ class RecordsByAgencyUsetype(CountRecordsReport):
         self.data["agency-use type"] = (
             self.data["AGENCY"] + " - " + self.data["USETYPE"].str.replace("-", "/")
         )
-        self.by_agency = True
         self.y_axis_col = "agency-use type"
         self.y_axis_label = "Agency/use type combination"
-        self.by_usetype = True
         self.category_plural = "agency/use type combinations"
         self.title = "City owned and leased properties by agency and usetype"
         self.title_anchor = "count_by_agency_usetype"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -7,7 +7,7 @@ import plotly.express as px
 class CountRecordsReport(ABC):
     def __call__(self):
         if self.data is None:
-            st.info(f"No Count of records by {self.X_axis_col}")
+            st.info(f"No Count of records by {self.x_axis_col}")
             return
         by_agency = ""
         middle_str = ""
@@ -36,13 +36,13 @@ class CountRecordsReport(ABC):
             self.data.iloc[
                 :x_lim,
             ],
-            x=self.X_axis_col,
+            x=self.x_axis_col,
             y="count",
             width=1000,
             color_discrete_sequence=COLOR_SCHEME,
         )
 
-        fig1.update_xaxes(title=self.X_axis_col[0] + self.X_axis_col[1:].lower())
+        fig1.update_xaxes(title=self.x_axis_col[0] + self.x_axis_col[1:].lower())
         fig1.update_layout(legend_title_text="Count")
 
         st.plotly_chart(fig1)
@@ -52,7 +52,7 @@ class RecordsByAgency(CountRecordsReport):
     def __init__(self, records_by_agency) -> None:
         self.data = records_by_agency
         self.by_agency = True
-        self.X_axis_col = "AGENCY"
+        self.x_axis_col = "AGENCY"
         self.by_usetype = False
         self.category_plural = "Agencies"
 
@@ -61,7 +61,7 @@ class RecordsByUsetype(CountRecordsReport):
     def __init__(self, records_by_usetype) -> None:
         self.data = records_by_usetype
         self.by_agency = False
-        self.X_axis_col = "USETYPE"
+        self.x_axis_col = "USETYPE"
         self.by_usetype = True
         self.category_plural = "Use types"
 
@@ -73,6 +73,6 @@ class RecordsByAgencyUsetype(CountRecordsReport):
             self.data["AGENCY"] + " - " + self.data["USETYPE"]
         )
         self.by_agency = True
-        self.X_axis_col = "agency-use type"
+        self.x_axis_col = "agency-use type"
         self.by_usetype = True
         self.category_plural = "Agency-use type combinations"

--- a/src/colp/components/agency_usetype_report.py
+++ b/src/colp/components/agency_usetype_report.py
@@ -25,16 +25,15 @@ class CountRecordsReport(ABC):
         )
 
     def plot(self):
-        x_lim = st.number_input(
-            label=f"{self.category_plural} to visualize",
-            min_value=2,
-            max_value=self.data.shape[0],
-            value=12,
+        slider_input = st.select_slider(
+            label=f"Most common {self.category_plural} to visualize",
+            options=range(1, self.data.shape[0] + 1),
+            value=(1, 12),
         )
         self.data.sort_values(by="count", ascending=False, inplace=True)
         fig1 = px.bar(
             self.data.iloc[
-                :x_lim,
+                slider_input[0] : slider_input[1],
             ].sort_values(by="count", ascending=True),
             y=self.y_axis_col,
             x="count",

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from typing import Dict
+import streamlit as st
 
 BUCKET_NAME = "edm-publishing"
 
@@ -9,9 +9,17 @@ def get_data(branch):
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
 
     rv["modified_names"] = csv_from_DO(f"{url}/ipis_modified_names.csv")
+    rv["records_by_agency"] = csv_from_DO(f"{url}/records_by_agency.csv")
+    rv["records_by_usetype"] = csv_from_DO(f"{url}/records_by_usetype.csv")
+    rv["records_by_agency_usetype"] = csv_from_DO(
+        f"{url}/records_by_agency_usetype.csv"
+    )
 
     return rv
 
 
 def csv_from_DO(url, kwargs={}):
-    return pd.read_csv(url, **kwargs)
+    try:
+        return pd.read_csv(url, **kwargs)
+    except:
+        st.warning(f"{url} not found")


### PR DESCRIPTION
Medium PR, could use two reviewers 🏞️ 

Addresses issue #174 that Jingyi laid out. You can see the code to create tables on pipeline in [this PR](https://github.com/NYCPlanning/db-colp/pull/220). I adapted [this CPDB code](https://github.com/NYCPlanning/data-engineering-qaqc/blob/7fe07adb1c8bec6eeff4dc941e900aad7741b621/src/cpdb/cpdb.py#L100) for the plots and tried to follow the convention laid out in the [pluto corrections report](https://github.com/NYCPlanning/data-engineering-qaqc/blob/master/src/pluto/components/corrections_report.py) code

One outstanding question before we merge is how to keep the plots on the screen. I wrote up issue #185, hoping that someone who worked on CPDB QAQC can help me keep the plots on the screen the way that page does.

Making streamlit reports is hard! These three little tables took me almost all day to produce. Helps put in perspective the volume of work we've achieved this summer