### PR TITLE
Create one outlier report to show mismatch between IPIS cd and PLUTO

### DIFF
--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -5,6 +5,7 @@ def colp():
     import os
     import pdb
     from src.colp.helpers import get_data
+    from src.colp.components.outlier_report import OutlierReport
 
     st.title("City Owned and Leased Properties QAQC")
     branch = st.sidebar.selectbox("select a branch", ["main"])
@@ -22,3 +23,4 @@ def colp():
     )
 
     data = get_data(branch)
+    OutlierReport(data=data)()

--- a/src/colp/components/outlier_report.py
+++ b/src/colp/components/outlier_report.py
@@ -1,0 +1,29 @@
+import streamlit as st
+import pandas as pd
+
+
+class OutlierReport:
+    def __init__(self, data):
+        self.ipis_cd_errors = data["ipis_cd_errors"]
+
+    def __call__(self):
+        st.subheader("Outlier Report")
+        st.markdown(
+            """
+            This section shows mismatch between IPIS community district and PLUTO.
+            """
+        )
+        if self.ipis_cd_errors is None:
+            st.info(
+                "No QAQC table for mismatch between IPIS community district and PLUTO."
+            )
+            return
+        self.display_ipis_mismatch()
+
+    def display_ipis_mismatch(self):
+        st.markdown("#### Mismatch between IPIS Community District and PLUTO")
+        df = self.ipis_cd_errors[~self.ipis_cd_errors["pluto_cd"].isnull()]
+        df["BBL"] = df["BBL"].astype(int)
+        df["pluto_cd"] = df["pluto_cd"].astype(int)
+        df = df.drop(columns=["uid"])
+        st.write(df)

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -8,8 +8,7 @@ def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
 
-    rv["modified_names"] = csv_from_DO(f"{url}/ipis_modified_names.csv")
-
+    rv["ipis_cd_errors"] = csv_from_DO(f"{url}/ipis_cd_errors.csv")
     return rv
 
 


### PR DESCRIPTION
Address the issue [here ](https://github.com/NYCPlanning/data-engineering-qaqc/issues/176). I think displaying the mismatch between IPIS community district and PLUTO may be more useful for the app, compared to showing changes in parcel name and house numbers, as most of the changes are not insightful.