### PR TITLE
add geospatial check table

### DIFF
--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -10,7 +10,9 @@ def colp():
     from src.colp.components.geospatial_check import GeospatialCheck
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox("select a branch", ["dev", "main"])
+    branch = st.sidebar.selectbox(
+        "select a branch", ["dev", "212-Records-by-Agency-Usetype", "main"]
+    )
     st.markdown(
         body="""
         ### About COLP Database

--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -4,11 +4,13 @@ def colp():
     import numpy as np
     import os
     import pdb
+    import json
     from src.colp.helpers import get_data
     from src.colp.components.outlier_report import OutlierReport
+    from src.colp.components.geospatial_check import GeospatialCheck
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox("select a branch", ["main"])
+    branch = st.sidebar.selectbox("select a branch", ["dev","main"])
     st.markdown(
         body="""
         ### About COLP Database
@@ -24,3 +26,5 @@ def colp():
 
     data = get_data(branch)
     OutlierReport(data=data)()
+    GeospatialCheck(data=data)()
+

--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -10,7 +10,7 @@ def colp():
     from src.colp.components.geospatial_check import GeospatialCheck
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox("select a branch", ["dev","main"])
+    branch = st.sidebar.selectbox("select a branch", ["dev", "main"])
     st.markdown(
         body="""
         ### About COLP Database
@@ -27,4 +27,3 @@ def colp():
     data = get_data(branch)
     OutlierReport(data=data)()
     GeospatialCheck(data=data)()
-

--- a/src/colp/components/geospatial_check.py
+++ b/src/colp/components/geospatial_check.py
@@ -10,34 +10,32 @@ class GeospatialCheck:
     def __call__(self):
         st.subheader("Geospatial Check")
         if self.geospatial_check is None:
-            st.info(
-                "Geospatial Check Table Not Found"
-            )
+            st.info("Geospatial Check Table Not Found")
             return
         df = self.geospatial_check
         df["result"] = df["result"].apply(json.loads)
         all_records = df.to_dict("records")
         self.display_not_in_nyc(all_records[0])
         self.display_nonmatch(all_records[1])
-        
 
-    def display_not_in_nyc(self,records):
+    def display_not_in_nyc(self, records):
         st.markdown("#### Properties That Are Not in NYC Borough Boundaries")
-        records=records["result"][0]["values"]
+        records = records["result"][0]["values"]
         if records:
             df = pd.DataFrame(records)
             st.write(df)
         else:
             st.info("All properties are within NYC Borough Boundaries.")
 
-    def display_nonmatch(self,records):
+    def display_nonmatch(self, records):
         st.markdown("#### Properties That Have Inconsistent Geographies")
-        st.markdown("We want to check whether the geocoded results lined up with other geography attributes in the data products.\
-        The Borocode is checked against both Community District and BBL.")
-        records=records["result"][0]["values"]
+        st.markdown(
+            "We want to check whether the geocoded results lined up with other geography attributes in the data products.\
+        The Borocode is checked against both Community District and BBL."
+        )
+        records = records["result"][0]["values"]
         if records:
             df = pd.DataFrame(records)
             st.write(df)
         else:
             st.info("No inconsistent geographies in the current version.")
-        

--- a/src/colp/components/geospatial_check.py
+++ b/src/colp/components/geospatial_check.py
@@ -23,7 +23,10 @@ class GeospatialCheck:
             return str(v[:4]) + "-" + str(v[4:])
 
     def display_not_in_nyc(self, records):
-        st.markdown("#### Properties That Are Not in NYC Borough Boundaries")
+        st.subheader("Properties That Are Not in NYC Borough Boundaries")
+        st.markdown(
+            "We want to check if there is any property that is located outside NYC Borough Boundaries (water included)."
+        )
         records = records["result"][0]["values"]
         if records:
             df = pd.DataFrame(records)
@@ -36,7 +39,7 @@ class GeospatialCheck:
             st.info("All properties are within NYC Borough Boundaries.")
 
     def display_nonmatch(self, records):
-        st.markdown("#### Properties That Have Inconsistent Geographies")
+        st.subheader("Properties That Have Inconsistent Geographies")
         st.markdown(
             "We want to check whether the geocoded results lined up with other geography attributes in the data products.\
         The Borocode is checked against both Community District and BBL."

--- a/src/colp/components/geospatial_check.py
+++ b/src/colp/components/geospatial_check.py
@@ -1,0 +1,43 @@
+import streamlit as st
+import pandas as pd
+import json
+
+
+class GeospatialCheck:
+    def __init__(self, data):
+        self.geospatial_check = data["geospatial_check"]
+
+    def __call__(self):
+        st.subheader("Geospatial Check")
+        if self.geospatial_check is None:
+            st.info(
+                "Geospatial Check Table Not Found"
+            )
+            return
+        df = self.geospatial_check
+        df["result"] = df["result"].apply(json.loads)
+        all_records = df.to_dict("records")
+        self.display_not_in_nyc(all_records[0])
+        self.display_nonmatch(all_records[1])
+        
+
+    def display_not_in_nyc(self,records):
+        st.markdown("#### Properties That Are Not in NYC Borough Boundaries")
+        records=records["result"][0]["values"]
+        if records:
+            df = pd.DataFrame(records)
+            st.write(df)
+        else:
+            st.info("All properties are within NYC Borough Boundaries.")
+
+    def display_nonmatch(self,records):
+        st.markdown("#### Properties That Have Inconsistent Geographies")
+        st.markdown("We want to check whether the geocoded results lined up with other geography attributes in the data products.\
+        The Borocode is checked against both Community District and BBL.")
+        records=records["result"][0]["values"]
+        if records:
+            df = pd.DataFrame(records)
+            st.write(df)
+        else:
+            st.info("No inconsistent geographies in the current version.")
+        

--- a/src/colp/components/geospatial_check.py
+++ b/src/colp/components/geospatial_check.py
@@ -18,11 +18,19 @@ class GeospatialCheck:
         self.display_not_in_nyc(all_records[0])
         self.display_nonmatch(all_records[1])
 
+    def cast_version(self, v):
+        if len(v) == 6:
+            return str(v[:4]) + "-" + str(v[4:])
+
     def display_not_in_nyc(self, records):
         st.markdown("#### Properties That Are Not in NYC Borough Boundaries")
         records = records["result"][0]["values"]
         if records:
             df = pd.DataFrame(records)
+            uid = df["uid"]
+            df = df.drop(columns="uid")
+            df = pd.concat([df, uid], axis=1)
+            df["v"] = df["v"].apply(lambda x: self.cast_version(x))
             st.write(df)
         else:
             st.info("All properties are within NYC Borough Boundaries.")
@@ -36,6 +44,10 @@ class GeospatialCheck:
         records = records["result"][0]["values"]
         if records:
             df = pd.DataFrame(records)
+            uid = df["uid"]
+            df = df.drop(columns="uid")
+            df["v"] = df["v"].apply(lambda x: self.cast_version(x))
+            df = pd.concat([df, uid], axis=1)
             st.write(df)
         else:
             st.info("No inconsistent geographies in the current version.")

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -6,7 +6,10 @@ BUCKET_NAME = "edm-publishing"
 
 def get_data(branch):
     rv = {}
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
+    if branch == "dev":
+        url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output/qaqc"
+    else:
+        url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
 
     rv["ipis_cd_errors"] = csv_from_DO(f"{url}/ipis_cd_errors.csv")
     rv["geospatial_check"] = csv_from_DO(f"{url}/geospatial_check.csv")

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -9,6 +9,7 @@ def get_data(branch):
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
 
     rv["ipis_cd_errors"] = csv_from_DO(f"{url}/ipis_cd_errors.csv")
+    rv["geospatial_check"] = csv_from_DO(f"{url}/geospatial_check.csv")
     return rv
 
 


### PR DESCRIPTION
Addresses the issue[ here](https://github.com/NYCPlanning/data-engineering-qaqc/issues/177). Thanks to Te's great work, we display two parts for the geospatial check, one is to check whether all properties are within NYC borough boundaries water included, the other is to check whether there is any inconsistency between geographies. 