### PR TITLE
Draft: 182: Caching and Digital Ocean Abstraction

### DIFF
--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -1,9 +1,6 @@
-from codecs import utf_8_encode
 import pandas as pd
 from dotenv import load_dotenv
 import geopandas as gpd
-import shutil
-from datetime import datetime
 from src.digital_ocean_client import DigitalOceanClient
 
 load_dotenv()
@@ -27,23 +24,16 @@ VIZKEY = {
 where would this list comes from? """
 
 
-def unzip_shapefile(zipfile, table):
-    try:
-        with zipfile as zf:
-            time = str(datetime.now().timestamp)
-            zf.extractall(path=f".library/{time}/{table}/")
-            gdf = gpd.read_file(f".library/{time}/{table}/{table}.shp")
-            shutil.rmtree(path=f".library/{time}")
-            return gdf
-    except:
-        return None
-
-
 def get_geometries(branch, table) -> dict:
-    points_zip = digital_ocean_client().zip_from_DO(
+    client = digital_ocean_client()
+    cache_key = client.cache_key(
+        f"db-cpdb/{branch}/latest/output/analysis/cpdb_summarystats_sagency.csv"
+    )
+
+    points_zip = client.zip_from_DO(
         zip_filename=f"db-cpdb/{branch}/latest/output/{table}.shp.zip"
     )
-    gdf = unzip_shapefile(
+    gdf = client.unzip_shapefile(
         zipfile=points_zip,
         table=table,
     )

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -1,18 +1,16 @@
 from codecs import utf_8_encode
-from io import StringIO
-import os
 import pandas as pd
-import boto3
 from dotenv import load_dotenv
 import geopandas as gpd
-from zipfile import ZipFile
-from io import BytesIO
 import shutil
 from datetime import datetime
+from src.digital_ocean_client import DigitalOceanClient
 
 load_dotenv()
 
+
 BUCKET_NAME = "edm-private"
+REPO_NAME = "db-cpdb"
 
 VIZKEY = {
     "all categories": {
@@ -28,25 +26,6 @@ VIZKEY = {
 """a feedback from the group is to have a dictionary from the abbreviation for agency for something more explicity
 where would this list comes from? """
 
-def s3_resource():
-    return boto3.resource(
-        "s3",
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-        endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
-    )
-
-def get_csv(bucket, csv_filename):
-    obj = s3_resource().Object(bucket_name=bucket, key=csv_filename)
-    s = str(obj.get()["Body"].read(), "utf8")
-    data = StringIO(s)
-    return pd.read_csv(data, encoding="utf8")
-
-def zip_from_DO(zip_filename, bucket):
-    zip_obj = s3_resource().Object(bucket_name=bucket, key=zip_filename)
-    buffer = BytesIO(zip_obj.get()["Body"].read())
-
-    return ZipFile(buffer)
 
 def unzip_shapefile(zipfile, table):
     try:
@@ -59,13 +38,14 @@ def unzip_shapefile(zipfile, table):
     except:
         return None
 
+
 def get_geometries(branch, table) -> dict:
-    points_zip = zip_from_DO(
-        zip_filename=f"db-cpdb/{branch}/latest/output/{table}.shp.zip",
-        bucket=BUCKET_NAME,
+    points_zip = digital_ocean_client().zip_from_DO(
+        zip_filename=f"db-cpdb/{branch}/latest/output/{table}.shp.zip"
     )
     gdf = unzip_shapefile(
-        zipfile=points_zip, table=table,
+        zipfile=points_zip,
+        table=table,
     )
     return gdf
 
@@ -75,37 +55,35 @@ def get_data(branch) -> dict:
     tables = {
         "analysis": ["cpdb_summarystats_sagency", "cpdb_summarystats_magency"],
         "others": ["cpdb_adminbounds"],
-        "no_version_compare":["geospatial_check"],
-        "geometries": ["cpdb_dcpattributes_pts", "cpdb_dcpattributes_poly" ]
+        "no_version_compare": ["geospatial_check"],
+        "geometries": ["cpdb_dcpattributes_pts", "cpdb_dcpattributes_poly"],
     }
-    
+
+    client = digital_ocean_client()
+
     for t in tables["analysis"]:
-        rv[t] = get_csv(
-            bucket=BUCKET_NAME, 
-            csv_filename=f"db-cpdb/{branch}/latest/output/analysis/{t}.csv",
+        rv[t] = client.csv_from_DO(
+            url=f"db-cpdb/{branch}/latest/output/analysis/{t}.csv",
         )
-        rv["pre_" + t] = get_csv(
-            bucket=BUCKET_NAME, 
-            csv_filename=f"db-cpdb/main/2022-04-15/output/analysis/{t}.csv",
+        rv["pre_" + t] = client.csv_from_DO(
+            url=f"db-cpdb/main/2022-04-15/output/analysis/{t}.csv",
         )
     for t in tables["others"]:
-        rv[t] = get_csv(
-            bucket=BUCKET_NAME, 
-            csv_filename=f"db-cpdb/{branch}/latest/output/{t}.csv",
+        rv[t] = client.csv_from_DO(
+            url=f"db-cpdb/{branch}/latest/output/{t}.csv",
         )
-        rv["pre_" + t] = get_csv(
-            bucket=BUCKET_NAME, 
-            csv_filename=f"db-cpdb/main/2022-04-15/output/{t}.csv",
+        rv["pre_" + t] = client.csv_from_DO(
+            url=f"db-cpdb/main/2022-04-15/output/{t}.csv",
         )
     for t in tables["no_version_compare"]:
-        rv[t] = get_csv(
-            bucket=BUCKET_NAME, 
-            csv_filename=f"db-cpdb/{branch}/latest/output/{t}.csv",
+        rv[t] = client.csv_from_DO(
+            url=f"db-cpdb/{branch}/latest/output/{t}.csv",
         )
     for t in tables["geometries"]:
         rv[t] = get_geometries(branch, table=t)
     print(rv.keys())
     return rv
+
 
 def get_commit_cols(df: pd.DataFrame):
     full_cols = df.columns
@@ -126,8 +104,7 @@ def get_map_percent_diff(df: pd.DataFrame, df_pre: pd.DataFrame, keys: dict):
     )
 
     diff["percent_mapped"] = df[keys["values"][1]] / df[keys["values"][0]]
-    diff["pre_percent_mapped"] = df_pre[keys["values"][1]] / \
-        df_pre[keys["values"][0]]
+    diff["pre_percent_mapped"] = df_pre[keys["values"][1]] / df_pre[keys["values"][0]]
     diff["diff_percent_mapped"] = diff.percent_mapped - diff.pre_percent_mapped
     diff.sort_values(by="diff_percent_mapped", inplace=True, ascending=True)
 
@@ -143,3 +120,7 @@ def sort_base_on_option(
     )
 
     return df_sort
+
+
+def digital_ocean_client():
+    return DigitalOceanClient(bucket_name=BUCKET_NAME, repo_name=REPO_NAME)

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -60,24 +60,27 @@ def get_data(branch) -> dict:
     }
 
     client = digital_ocean_client()
+    cache_key = client.cache_key(
+        f"db-cpdb/{branch}/latest/output/analysis/cpdb_summarystats_sagency.csv"
+    )
 
     for t in tables["analysis"]:
         rv[t] = client.csv_from_DO(
-            url=f"db-cpdb/{branch}/latest/output/analysis/{t}.csv",
+            url=f"db-cpdb/{branch}/latest/output/analysis/{t}.csv", cache_key=cache_key
         )
         rv["pre_" + t] = client.csv_from_DO(
-            url=f"db-cpdb/main/2022-04-15/output/analysis/{t}.csv",
+            url=f"db-cpdb/main/2022-04-15/output/analysis/{t}.csv", cache_key=cache_key
         )
     for t in tables["others"]:
         rv[t] = client.csv_from_DO(
-            url=f"db-cpdb/{branch}/latest/output/{t}.csv",
+            url=f"db-cpdb/{branch}/latest/output/{t}.csv", cache_key=cache_key
         )
         rv["pre_" + t] = client.csv_from_DO(
-            url=f"db-cpdb/main/2022-04-15/output/{t}.csv",
+            url=f"db-cpdb/main/2022-04-15/output/{t}.csv", cache_key=cache_key
         )
     for t in tables["no_version_compare"]:
         rv[t] = client.csv_from_DO(
-            url=f"db-cpdb/{branch}/latest/output/{t}.csv",
+            url=f"db-cpdb/{branch}/latest/output/{t}.csv", cache_key=cache_key
         )
     for t in tables["geometries"]:
         rv[t] = get_geometries(branch, table=t)

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -165,31 +165,42 @@ QAQC_CHECK_DICTIONARY = {
     "manual_corrections_not_applied": {
         "description": "This will return the full list of jobs that have any manual corrections did not get applied.",
         "field_type": "boolean",
-        "section": "n/a"
-    }
+        "section": "n/a",
+    },
 }
+
 
 def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
 
     client = digital_ocean_client()
-
-    rv["qaqc_app"] = client.csv_from_DO(
-        f"{url}/qaqc_app.csv",
-        kwargs={"dtype": {"job_number": "str"}},
+    cache_key = client.cache_key(
+        url=f"db-developments/{branch}/latest/output/version.txt"
     )
 
-    rv["qaqc_historic"] = client.csv_from_DO(f"{url}/qaqc_historic.csv")
+    rv["qaqc_app"] = client.csv_from_DO(
+        url=f"{url}/qaqc_app.csv",
+        cache_key=cache_key,
+        _kwargs={"dtype": {"job_number": "str"}},
+    )
+
+    rv["qaqc_historic"] = client.csv_from_DO(
+        url=f"{url}/qaqc_historic.csv", cache_key=cache_key
+    )
 
     rv["qaqc_field_distribution"] = client.csv_from_DO(
         f"{url}/qaqc_field_distribution.csv",
-        kwargs={"converters": {"result": json.loads}},
+        cache_key=cache_key,
+        _kwargs={"converters": {"result": json.loads}},
     )
 
-    rv["qaqc_quarter_check"] = client.csv_from_DO(f"{url}/qaqc_quarter_check.csv")
+    rv["qaqc_quarter_check"] = client.csv_from_DO(
+        url=f"{url}/qaqc_quarter_check.csv", cache_key=cache_key
+    )
 
     return rv
+
 
 def digital_ocean_client():
     return DigitalOceanClient(bucket_name=BUCKET_NAME, repo_name=REPO_NAME)

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -3,8 +3,10 @@ from typing import Dict
 from urllib.error import HTTPError
 import streamlit as st
 import json
+from src.digital_ocean_client import DigitalOceanClient
 
 BUCKET_NAME = "edm-publishing"
+REPO_NAME = "db-developments"
 
 QAQC_CHECK_SECTIONS = {
     "Class B": "These checks are related to class A and class B unit distinctions.",
@@ -171,25 +173,23 @@ def get_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
 
-    rv["qaqc_app"] = csv_from_DO(
+    client = digital_ocean_client()
+
+    rv["qaqc_app"] = client.csv_from_DO(
         f"{url}/qaqc_app.csv",
         kwargs={"dtype": {"job_number": "str"}},
     )
 
-    rv["qaqc_historic"] = csv_from_DO(f"{url}/qaqc_historic.csv")
+    rv["qaqc_historic"] = client.csv_from_DO(f"{url}/qaqc_historic.csv")
 
-    rv["qaqc_field_distribution"] = csv_from_DO(
+    rv["qaqc_field_distribution"] = client.csv_from_DO(
         f"{url}/qaqc_field_distribution.csv",
         kwargs={"converters": {"result": json.loads}},
     )
 
-    rv["qaqc_quarter_check"] = csv_from_DO(f"{url}/qaqc_quarter_check.csv")
+    rv["qaqc_quarter_check"] = client.csv_from_DO(f"{url}/qaqc_quarter_check.csv")
 
     return rv
 
-
-def csv_from_DO(url, kwargs={}):
-    try:
-        return pd.read_csv(url, **kwargs)
-    except:
-        st.warning(f"{url} not found")
+def digital_ocean_client():
+    return DigitalOceanClient(bucket_name=BUCKET_NAME, repo_name=REPO_NAME)

--- a/src/digital_ocean_client.py
+++ b/src/digital_ocean_client.py
@@ -7,6 +7,9 @@ import os
 from dotenv import load_dotenv
 import pdb
 import streamlit as st
+from datetime import datetime
+import shutil
+import geopandas as gpd
 
 load_dotenv()
 
@@ -36,6 +39,17 @@ class DigitalOceanClient:
         except:
             return None
 
+    def unzip_shapefile(self, table, zipfile):
+        try:
+            with zipfile as zf:
+                time = str(datetime.now().timestamp)
+                zf.extractall(path=f".library/{time}/{table}/")
+                gdf = gpd.read_file(f".library/{time}/{table}/{table}.shp")
+                shutil.rmtree(path=f".library/{time}")
+                return gdf
+        except:
+            return None
+
     def s3_resource(self):
         return boto3.resource(
             "s3",
@@ -44,8 +58,9 @@ class DigitalOceanClient:
             endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
         )
 
-    # @st.experimental_memo
+    @st.experimental_memo
     def csv_from_DO(_self, url, cache_key, _kwargs={}):
+        print("cache miss")
         try:
             if _self.bucket_name == "edm-publishing":
                 return pd.read_csv(url, **_kwargs)

--- a/src/digital_ocean_client.py
+++ b/src/digital_ocean_client.py
@@ -5,6 +5,8 @@ from zipfile import ZipFile
 from io import StringIO
 import os
 from dotenv import load_dotenv
+import pdb
+import streamlit as st
 
 load_dotenv()
 
@@ -13,6 +15,13 @@ class DigitalOceanClient:
     def __init__(self, bucket_name, repo_name):
         self.bucket_name = bucket_name
         self.repo_name = repo_name
+
+    def cache_key(self, url):
+        return str(
+            self.s3_resource()
+            .ObjectSummary(bucket_name=self.bucket_name, key=url)
+            .last_modified
+        )
 
     def bucket(self):
         return self.s3_resource().Bucket(self.bucket_name)
@@ -34,13 +43,14 @@ class DigitalOceanClient:
             aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
             endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
         )
-    
-    def csv_from_DO(self, url, kwargs={}):
+
+    # @st.experimental_memo
+    def csv_from_DO(_self, url, cache_key, _kwargs={}):
         try:
-            if self.bucket_name == "edm-publishing":
-                return pd.read_csv(url, **kwargs)
+            if _self.bucket_name == "edm-publishing":
+                return pd.read_csv(url, **_kwargs)
             else:
-                return self.private_csv_from_DO(url, kwargs)
+                return _self.private_csv_from_DO(url, _kwargs)
         except:
             return None
 

--- a/src/digital_ocean_client.py
+++ b/src/digital_ocean_client.py
@@ -34,12 +34,15 @@ class DigitalOceanClient:
             aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
             endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
         )
-
+    
     def csv_from_DO(self, url, kwargs={}):
-        if self.bucket_name == "edm-publishing":
-            return pd.read_csv(url, **kwargs)
-        else:
-            return self.private_csv_from_DO(url, kwargs)
+        try:
+            if self.bucket_name == "edm-publishing":
+                return pd.read_csv(url, **kwargs)
+            else:
+                return self.private_csv_from_DO(url, kwargs)
+        except:
+            return None
 
     def private_csv_from_DO(self, url, kwargs):
         obj = self.s3_resource().Object(bucket_name=self.bucket_name, key=url)

--- a/src/digital_ocean_client.py
+++ b/src/digital_ocean_client.py
@@ -1,0 +1,57 @@
+import boto3
+import pandas as pd
+from io import BytesIO
+from zipfile import ZipFile
+from io import StringIO
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class DigitalOceanClient:
+    def __init__(self, bucket_name, repo_name):
+        self.bucket_name = bucket_name
+        self.repo_name = repo_name
+
+    def bucket(self):
+        return self.s3_resource().Bucket(self.bucket_name)
+
+    def get_folders(self):
+        return self.bucket().objects.filter(Prefix=f"{self.repo_name}/")
+
+    def unzip_csv(self, csv_filename, zipfile):
+        try:
+            with zipfile.open(csv_filename) as csv:
+                return pd.read_csv(csv, true_values=["t"], false_values=["f"])
+        except:
+            return None
+
+    def s3_resource(self):
+        return boto3.resource(
+            "s3",
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
+        )
+
+    def csv_from_DO(self, url, kwargs={}):
+        if self.bucket_name == "edm-publishing":
+            return pd.read_csv(url, **kwargs)
+        else:
+            return self.private_csv_from_DO(url, kwargs)
+
+    def private_csv_from_DO(self, url, kwargs):
+        obj = self.s3_resource().Object(bucket_name=self.bucket_name, key=url)
+        s = str(obj.get()["Body"].read(), "utf8")
+        data = StringIO(s)
+
+        return pd.read_csv(data, encoding="utf8", **kwargs)
+
+    def zip_from_DO(self, zip_filename):
+        zip_obj = self.s3_resource().Object(
+            bucket_name=self.bucket_name, key=zip_filename
+        )
+        buffer = BytesIO(zip_obj.get()["Body"].read())
+
+        return ZipFile(buffer)

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -18,7 +18,7 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
 
     client = digital_ocean_client()
     cache_key = client.cache_key(
-        f"db-pluto/{branch}/latest/output/qaqc/qaqc_mismatch.csv"
+        f"db-pluto/{branch}/latest/output/source_data_versions.csv"
     )
 
     kwargs = {"true_values": ["t"], "false_values": ["f"]}

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -1,51 +1,51 @@
-import boto3
 import re
 import pandas as pd
 from datetime import datetime
 import json
 from typing import Dict
-import os
 from dotenv import load_dotenv
-from zipfile import ZipFile
-from io import BytesIO
+from src.digital_ocean_client import DigitalOceanClient
 
 load_dotenv()
 
 BUCKET_NAME = "edm-publishing"
+REPO_NAME = "db-pluto"
 
 
 def get_data(branch) -> Dict[str, pd.DataFrame]:
     rv = {}
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/latest/output/qaqc"
-    rv["df_mismatch"] = csv_from_DO(f"{url}/qaqc_mismatch.csv")
-    rv["df_null"] = csv_from_DO(f"{url}/qaqc_null.csv")
-    rv["df_aggregate"] = csv_from_DO(f"{url}/qaqc_aggregate.csv")
-    rv["df_expected"] = csv_from_DO(
-        f"{url}/qaqc_expected.csv", kwargs={"converters": {"expected": json.loads}}
+    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/latest/output"
+
+    client = digital_ocean_client()
+    kwargs = {"true_values": ["t"], "false_values": ["t"]}
+    rv["df_mismatch"] = client.csv_from_DO(f"{url}/qaqc/qaqc_mismatch.csv", kwargs)
+    rv["df_null"] = client.csv_from_DO(f"{url}/qaqc/qaqc_null.csv", kwargs)
+    rv["df_aggregate"] = client.csv_from_DO(f"{url}/qaqc/qaqc_aggregate.csv", kwargs)
+    rv["df_expected"] = client.csv_from_DO(
+        f"{url}/qaqc/qaqc_expected.csv",
+        kwargs={"converters": {"expected": json.loads}} | kwargs,
     )
-    rv["df_outlier"] = csv_from_DO(
-        f"{url}/qaqc_outlier.csv", kwargs={"converters": {"outlier": json.loads}}
+    rv["df_outlier"] = client.csv_from_DO(
+        f"{url}/qaqc/qaqc_outlier.csv",
+        kwargs={"converters": {"outlier": json.loads}} | kwargs,
     )
 
-    pluto_corrections_zip = zip_from_DO(
-        zip_filename=f"db-pluto/{branch}/latest/output/pluto_corrections.zip",
-        bucket=BUCKET_NAME,
+    pluto_corrections_zip = client.zip_from_DO(
+        zip_filename=f"db-pluto/{branch}/latest/output/qaqc/pluto_corrections.zip",
     )
 
-    rv["pluto_corrections"] = unzip_csv(
+    rv["pluto_corrections"] = client.unzip_csv(
         csv_filename="pluto_corrections.csv", zipfile=pluto_corrections_zip
     )
 
-    rv["pluto_corrections_applied"] = unzip_csv(
+    rv["pluto_corrections_applied"] = client.unzip_csv(
         csv_filename="pluto_corrections_applied.csv", zipfile=pluto_corrections_zip
     )
-    rv["pluto_corrections_not_applied"] = unzip_csv(
+    rv["pluto_corrections_not_applied"] = client.unzip_csv(
         csv_filename="pluto_corrections_not_applied.csv", zipfile=pluto_corrections_zip
     )
 
-    source_data_versions = pd.read_csv(
-        f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/latest/output/source_data_versions.csv"
-    )
+    source_data_versions = client.csv_from_DO(f"{url}source_data_versions.csv")
 
     rv["source_data_version"] = source_data_versions
     sdv = source_data_versions.to_dict("records")
@@ -73,9 +73,8 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
 
 def get_branches():
     all_branches = set()
-    pub_bucket = s3_resource().Bucket(BUCKET_NAME)
 
-    for obj in pub_bucket.objects.filter(Prefix="db-pluto/"):
+    for obj in digital_ocean_client().get_folders():
         all_branches.add(obj._key.split("/")[1])
     rv = blacklist_branches(all_branches)
     return rv
@@ -102,29 +101,5 @@ def blacklist_branches(branches):
     return rv
 
 
-def csv_from_DO(url, kwargs={}):
-    return pd.read_csv(url, true_values=["t"], false_values=["f"], **kwargs)
-
-
-def unzip_csv(csv_filename, zipfile):
-    try:
-        with zipfile.open(csv_filename) as csv:
-            return pd.read_csv(csv, true_values=["t"], false_values=["f"])
-    except:
-        return None
-
-
-def zip_from_DO(zip_filename, bucket):
-    zip_obj = s3_resource().Object(bucket_name=bucket, key=zip_filename)
-    buffer = BytesIO(zip_obj.get()["Body"].read())
-
-    return ZipFile(buffer)
-
-
-def s3_resource():
-    return boto3.resource(
-        "s3",
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-        endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
-    )
+def digital_ocean_client():
+    return DigitalOceanClient(bucket_name=BUCKET_NAME, repo_name=REPO_NAME)

--- a/src/pluto/helpers.py
+++ b/src/pluto/helpers.py
@@ -17,21 +17,33 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-pluto/{branch}/latest/output"
 
     client = digital_ocean_client()
-    kwargs = {"true_values": ["t"], "false_values": ["t"]}
-    rv["df_mismatch"] = client.csv_from_DO(f"{url}/qaqc/qaqc_mismatch.csv", kwargs)
-    rv["df_null"] = client.csv_from_DO(f"{url}/qaqc/qaqc_null.csv", kwargs)
-    rv["df_aggregate"] = client.csv_from_DO(f"{url}/qaqc/qaqc_aggregate.csv", kwargs)
+    cache_key = client.cache_key(
+        f"db-pluto/{branch}/latest/output/qaqc/qaqc_mismatch.csv"
+    )
+
+    kwargs = {"true_values": ["t"], "false_values": ["f"]}
+    rv["df_mismatch"] = client.csv_from_DO(
+        url=f"{url}/qaqc/qaqc_mismatch.csv", cache_key=cache_key, _kwargs=kwargs
+    )
+    rv["df_null"] = client.csv_from_DO(
+        url=f"{url}/qaqc/qaqc_null.csv", cache_key=cache_key, _kwargs=kwargs
+    )
+    rv["df_aggregate"] = client.csv_from_DO(
+        url=f"{url}/qaqc/qaqc_aggregate.csv", cache_key=cache_key, _kwargs=kwargs
+    )
     rv["df_expected"] = client.csv_from_DO(
-        f"{url}/qaqc/qaqc_expected.csv",
-        kwargs={"converters": {"expected": json.loads}} | kwargs,
+        url=f"{url}/qaqc/qaqc_expected.csv",
+        cache_key=cache_key,
+        _kwargs={"converters": {"expected": json.loads}} | kwargs,
     )
     rv["df_outlier"] = client.csv_from_DO(
-        f"{url}/qaqc/qaqc_outlier.csv",
-        kwargs={"converters": {"outlier": json.loads}} | kwargs,
+        url=f"{url}/qaqc/qaqc_outlier.csv",
+        cache_key=cache_key,
+        _kwargs={"converters": {"outlier": json.loads}} | kwargs,
     )
 
     pluto_corrections_zip = client.zip_from_DO(
-        zip_filename=f"db-pluto/{branch}/latest/output/qaqc/pluto_corrections.zip",
+        zip_filename=f"db-pluto/{branch}/latest/output/pluto_corrections.zip",
     )
 
     rv["pluto_corrections"] = client.unzip_csv(
@@ -45,7 +57,9 @@ def get_data(branch) -> Dict[str, pd.DataFrame]:
         csv_filename="pluto_corrections_not_applied.csv", zipfile=pluto_corrections_zip
     )
 
-    source_data_versions = client.csv_from_DO(f"{url}source_data_versions.csv")
+    source_data_versions = client.csv_from_DO(
+        url=f"{url}/source_data_versions.csv", cache_key=cache_key
+    )
 
     rv["source_data_version"] = source_data_versions
     sdv = source_data_versions.to_dict("records")

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -12,7 +12,6 @@ def pluto():
     from src.constants import COLOR_SCHEME
     from src.pluto.components.corrections_report import CorrectionsReport
     from numerize.numerize import numerize
-    import pdb
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -252,6 +251,7 @@ def pluto():
                 & (df_mismatch.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
                 :,
             ]
+
             v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
             v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
             v1v2_total = v1v2.pop("total")

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -12,6 +12,7 @@ def pluto():
     from src.constants import COLOR_SCHEME
     from src.pluto.components.corrections_report import CorrectionsReport
     from numerize.numerize import numerize
+    import pdb
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -251,7 +252,6 @@ def pluto():
                 & (df_mismatch.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
                 :,
             ]
-
             v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
             v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
             v1v2_total = v1v2.pop("total")


### PR DESCRIPTION
Addresses #182

Bigger change, needs 2 🐵 

First attempt at DRYing interactions with digital ocean and adding smarter caching - I still kind of eye a future development which removes this logic from one single get_data call and makes each report responsible for pulling just its own data from s3 but I think this makes that future (or a different one, whatever you guys choose) easier. For caching, I am hoping to take advantage of the fact that everything on the app side is updated at once, to just retrieve the last_modified_date for one file and use it as a cache key for the the rest of the data downloads.

Some things to note:

1. _argument tells streamlit to ignore trying to hash this argument into key, is necessary for "self". We really only care about the url and cache key as the unique combination of things to trigger a cache refresh
2. I placed the unzipping code in the digital_ocean_client because it all felt like it fit together in terms of "this class takes an app and a filepath and gives me back a pandas dataframe." But it doesn't quite fit the moniker of interactions with Digital Ocean directly.
3. We might choose to consider placing an empty file or a one line file at the root of a repo to act explicitly as a cache key, or consider what that might look like. This would allow us to more easily trigger a cache refresh manually by just touching that file.
4. I left colp alone to avoid stepping on current dev work, but think it wont be hard to fit it into this work later
