### PR TITLE
Pull files from nested `/qaqc` folder

### DIFF
--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -13,9 +13,7 @@ def colp():
     from src.colp.components.outlier_report import OutlierReport
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox(
-        "select a branch", ["main", "212-Records-by-Agency-Usetype"]
-    )
+    branch = st.sidebar.selectbox("select a branch", ["dev"])
     st.markdown(
         body="""
         ### About COLP Database

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -6,7 +6,7 @@ BUCKET_NAME = "edm-publishing"
 
 def get_data(branch):
     rv = {}
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
+    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output/qaqc"
 
     rv["modified_names"] = csv_from_DO(f"{url}/ipis_modified_names.csv")
     rv["records_by_agency"] = csv_from_DO(f"{url}/records_by_agency.csv")


### PR DESCRIPTION
Easy PR, one reviewer 🪆 
Now that all outstanding COLP PR's are merged in, we can just point the app to `dev` and assume that any new COLP branches also send their qaqc .csv files to the qaqc folder  