### PR TITLE
add manual correction report

### DIFF
--- a/src/colp/colp.py
+++ b/src/colp/colp.py
@@ -6,9 +6,10 @@ def colp():
     import pdb
     from src.colp.helpers import get_data
     from src.colp.components.outlier_report import OutlierReport
+    from src.colp.components.manual_correction_report import ManualCorrection
 
     st.title("City Owned and Leased Properties QAQC")
-    branch = st.sidebar.selectbox("select a branch", ["main"])
+    branch = st.sidebar.selectbox("select a branch", ["dev", "main"])
     st.markdown(
         body="""
         ### About COLP Database
@@ -24,3 +25,4 @@ def colp():
 
     data = get_data(branch)
     OutlierReport(data=data)()
+    ManualCorrection(data=data)()

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -18,11 +18,16 @@ class ManualCorrection:
             st.write("Manual correction table for applied records is not available.")
             return
         applied = self.modifications_applied
-        count1 = applied.groupby("field").size()
-        count1 = count1.reset_index()
-        count1.rename(columns={"field": "Field", 0: "Number of Records"}, inplace=True)
-        st.subheader("Numbers of Manual Corrections Applied By Field")
-        st.write(count1)
+        if not applied.empty:
+            count1 = applied.groupby("field").size()
+            count1 = count1.reset_index()
+            count1.rename(
+                columns={"field": "Field", 0: "Number of Records"}, inplace=True
+            )
+            st.subheader("Numbers of Manual Corrections Applied By Field")
+            st.write(count1)
+        else:
+            st.write("Manual correction table for applied records is empty.")
 
     def display_not_applied_correction(self, df):
         if df is None:
@@ -31,12 +36,17 @@ class ManualCorrection:
             )
             return
         not_applied = self.modifications_not_applied
-        count2 = not_applied.groupby("field").size()
-        count2 = count2.reset_index()
-        count2.rename(columns={"field": "Field", 0: "Number of Records"}, inplace=True)
-        st.subheader("Numbers of Manual Corrections Not Applied By Field")
-        st.write(count2)
-        not_applied = not_applied.sort_values(by=["field"])
-        not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
-        st.subheader("Table of Manual Corrections Not Applied")
-        AgGrid(not_applied)
+        if not not_applied.empty:
+            count2 = not_applied.groupby("field").size()
+            count2 = count2.reset_index()
+            count2.rename(
+                columns={"field": "Field", 0: "Number of Records"}, inplace=True
+            )
+            st.subheader("Numbers of Manual Corrections Not Applied By Field")
+            st.write(count2)
+            not_applied = not_applied.sort_values(by=["field"])
+            not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
+            st.subheader("Table of Manual Corrections Not Applied")
+            AgGrid(not_applied)
+        else:
+            st.write("Manual correction table for not applied records is empty.")

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -42,9 +42,9 @@ class ManualCorrection:
             )
             st.subheader("Numbers of Manual Corrections Not Applied By Field")
             st.write(count2)
-            not_applied = not_applied.sort_values(by=["field"])
-            not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
+            df = df.sort_values(by=["field"])
+            df = df[df.columns.tolist()[1:] + ["uid"]]
             st.subheader("Table of Manual Corrections Not Applied")
-            AgGrid(not_applied)
+            AgGrid(df)
         else:
             st.write("Manual correction table for not applied records is empty.")

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -1,0 +1,38 @@
+import streamlit as st
+import pandas as pd
+
+
+class ManualCorrection:
+    def __init__(self, data):
+        self.modifications_applied = data["modifications_applied"]
+        self.modifications_not_applied = data["modifications_not_applied"]
+
+    def __call__(self):
+        st.subheader("Manual Correction Report")
+
+        if (
+            self.modifications_applied is None
+            and self.modifications_not_applied is None
+        ):
+            st.info("No Manual Correction Table.")
+            return
+        self.display_manual_correction()
+
+    def display_manual_correction(self):
+        applied = self.modifications_applied
+        not_applied = self.modifications_not_applied
+        if not applied.empty:
+            count1 = applied.groupby("field").size()
+            count1.rename("Number of Records", inplace=True)
+            st.markdown("##### Numbers of Manual Corrections Applied By Field")
+            st.write(count1)
+        if not not_applied.empty:
+            count2 = not_applied.groupby("field").size()
+            count2.rename("Number of Records", inplace=True)
+            st.markdown("##### Numbers of Manual Corrections Not Applied By Field")
+            st.write(count2)
+            uid = not_applied["uid"]
+            not_applied = not_applied.drop(columns=["uid"]).sort_values(by=["field"])
+            not_applied = pd.concat([not_applied, uid], axis=1)
+            st.markdown("##### Table of Manual Corrections Not Applied")
+            st.write(not_applied)

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -16,11 +16,16 @@ class ManualCorrection:
         ):
             st.info("No Manual Correction Table Available.")
             return
-        self.display_manual_correction()
+        elif self.modifications_applied is None:
+            self.display_not_applied_correction()
+        elif self.modifications_not_applied is None:
+            self.display_applied_correction()
+        else:
+            self.display_applied_correction()
+            self.display_not_applied_correction()
 
-    def display_manual_correction(self):
+    def display_applied_correction(self):
         applied = self.modifications_applied
-        not_applied = self.modifications_not_applied
         if not applied.empty:
             count1 = applied.groupby("field").size()
             count1 = count1.reset_index()
@@ -29,6 +34,9 @@ class ManualCorrection:
             )
             st.subheader("Numbers of Manual Corrections Applied By Field")
             st.write(count1)
+
+    def display_not_applied_correction(self):
+        not_applied = self.modifications_not_applied
         if not not_applied.empty:
             count2 = not_applied.groupby("field").size()
             count2 = count2.reset_index()
@@ -38,5 +46,6 @@ class ManualCorrection:
             st.subheader("Numbers of Manual Corrections Not Applied By Field")
             st.write(count2)
             not_applied = not_applied.sort_values(by=["field"])
+            not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
             st.subheader("Table of Manual Corrections Not Applied")
             st.write(not_applied)

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -17,9 +17,8 @@ class ManualCorrection:
         if df is None:
             st.write("Manual correction table for applied records is not available.")
             return
-        applied = self.modifications_applied
-        if not applied.empty:
-            count1 = applied.groupby("field").size()
+        if not df.empty:
+            count1 = df.groupby("field").size()
             count1 = count1.reset_index()
             count1.rename(
                 columns={"field": "Field", 0: "Number of Records"}, inplace=True
@@ -35,9 +34,8 @@ class ManualCorrection:
                 "Manual correction table for not applied records is not available."
             )
             return
-        not_applied = self.modifications_not_applied
-        if not not_applied.empty:
-            count2 = not_applied.groupby("field").size()
+        if not df.empty:
+            count2 = df.groupby("field").size()
             count2 = count2.reset_index()
             count2.rename(
                 columns={"field": "Field", 0: "Number of Records"}, inplace=True

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+from st_aggrid import AgGrid
 
 
 class ManualCorrection:
@@ -9,43 +10,33 @@ class ManualCorrection:
 
     def __call__(self):
         st.subheader("Manual Correction Report")
+        self.display_applied_correction(self.modifications_applied)
+        self.display_not_applied_correction(self.modifications_not_applied)
 
-        if (
-            self.modifications_applied is None
-            and self.modifications_not_applied is None
-        ):
-            st.info("No Manual Correction Table Available.")
+    def display_applied_correction(self, df):
+        if df is None:
+            st.write("Manual correction table for applied records is not available.")
             return
-        elif self.modifications_applied is None:
-            self.display_not_applied_correction()
-        elif self.modifications_not_applied is None:
-            self.display_applied_correction()
-        else:
-            self.display_applied_correction()
-            self.display_not_applied_correction()
-
-    def display_applied_correction(self):
         applied = self.modifications_applied
-        if not applied.empty:
-            count1 = applied.groupby("field").size()
-            count1 = count1.reset_index()
-            count1.rename(
-                columns={"field": "Field", 0: "Number of Records"}, inplace=True
-            )
-            st.subheader("Numbers of Manual Corrections Applied By Field")
-            st.write(count1)
+        count1 = applied.groupby("field").size()
+        count1 = count1.reset_index()
+        count1.rename(columns={"field": "Field", 0: "Number of Records"}, inplace=True)
+        st.subheader("Numbers of Manual Corrections Applied By Field")
+        st.write(count1)
 
-    def display_not_applied_correction(self):
-        not_applied = self.modifications_not_applied
-        if not not_applied.empty:
-            count2 = not_applied.groupby("field").size()
-            count2 = count2.reset_index()
-            count2.rename(
-                columns={"field": "Field", 0: "Number of Records"}, inplace=True
+    def display_not_applied_correction(self, df):
+        if df is None:
+            st.write(
+                "Manual correction table for not applied records is not available."
             )
-            st.subheader("Numbers of Manual Corrections Not Applied By Field")
-            st.write(count2)
-            not_applied = not_applied.sort_values(by=["field"])
-            not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
-            st.subheader("Table of Manual Corrections Not Applied")
-            st.write(not_applied)
+            return
+        not_applied = self.modifications_not_applied
+        count2 = not_applied.groupby("field").size()
+        count2 = count2.reset_index()
+        count2.rename(columns={"field": "Field", 0: "Number of Records"}, inplace=True)
+        st.subheader("Numbers of Manual Corrections Not Applied By Field")
+        st.write(count2)
+        not_applied = not_applied.sort_values(by=["field"])
+        not_applied = not_applied[not_applied.columns.tolist()[1:] + ["uid"]]
+        st.subheader("Table of Manual Corrections Not Applied")
+        AgGrid(not_applied)

--- a/src/colp/components/manual_correction_report.py
+++ b/src/colp/components/manual_correction_report.py
@@ -14,7 +14,7 @@ class ManualCorrection:
             self.modifications_applied is None
             and self.modifications_not_applied is None
         ):
-            st.info("No Manual Correction Table.")
+            st.info("No Manual Correction Table Available.")
             return
         self.display_manual_correction()
 
@@ -23,16 +23,20 @@ class ManualCorrection:
         not_applied = self.modifications_not_applied
         if not applied.empty:
             count1 = applied.groupby("field").size()
-            count1.rename("Number of Records", inplace=True)
-            st.markdown("##### Numbers of Manual Corrections Applied By Field")
+            count1 = count1.reset_index()
+            count1.rename(
+                columns={"field": "Field", 0: "Number of Records"}, inplace=True
+            )
+            st.subheader("Numbers of Manual Corrections Applied By Field")
             st.write(count1)
         if not not_applied.empty:
             count2 = not_applied.groupby("field").size()
-            count2.rename("Number of Records", inplace=True)
-            st.markdown("##### Numbers of Manual Corrections Not Applied By Field")
+            count2 = count2.reset_index()
+            count2.rename(
+                columns={"field": "Field", 0: "Number of Records"}, inplace=True
+            )
+            st.subheader("Numbers of Manual Corrections Not Applied By Field")
             st.write(count2)
-            uid = not_applied["uid"]
-            not_applied = not_applied.drop(columns=["uid"]).sort_values(by=["field"])
-            not_applied = pd.concat([not_applied, uid], axis=1)
-            st.markdown("##### Table of Manual Corrections Not Applied")
+            not_applied = not_applied.sort_values(by=["field"])
+            st.subheader("Table of Manual Corrections Not Applied")
             st.write(not_applied)

--- a/src/colp/helpers.py
+++ b/src/colp/helpers.py
@@ -6,9 +6,16 @@ BUCKET_NAME = "edm-publishing"
 
 def get_data(branch):
     rv = {}
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
+    if branch == "dev":
+        url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output/qaqc"
+    else:
+        url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-colp/{branch}/latest/output"
 
     rv["ipis_cd_errors"] = csv_from_DO(f"{url}/ipis_cd_errors.csv")
+    rv["modifications_applied"] = csv_from_DO(f"{url}/modifications_applied.csv")
+    rv["modifications_not_applied"] = csv_from_DO(
+        f"{url}/modifications_not_applied.csv"
+    )
     return rv
 
 


### PR DESCRIPTION
Addresses the issue [here](https://github.com/NYCPlanning/data-engineering-qaqc/issues/178). The number of unique fields of these manual correction records is relatively small. I guess just displaying simple tables to show the number of corrections applied and not applied is enough. But I am not sure what is the best format to display such table and how to make the page look prettier.