### PR TITLE
Improve PLUTO Null Graph 

### DIFF
--- a/src/pluto/components/null_graph.py
+++ b/src/pluto/components/null_graph.py
@@ -19,9 +19,9 @@ class NullReport:
         st.subheader("Null Graph")
         field_range = st.slider(
             "Select which fields to display (ranked from most to least nulls)",
-            min_value=0,
+            min_value=1,
             max_value=len(self.fields),
-            value=[0, 12],
+            value=[1, 12],
         )
 
         df = self.df_null
@@ -160,7 +160,7 @@ class NullReport:
         ]
 
     def sort_and_filter_df(self, df, range, fields):
-        selected = fields[range[0] : range[1]]
+        selected = fields[range[0]-1 : range[1]]
         df = df[["pair"] + selected]
         df_transformed = df.set_index("pair").stack().reset_index()
         df_transformed.rename(

--- a/src/pluto/components/null_graph.py
+++ b/src/pluto/components/null_graph.py
@@ -1,0 +1,193 @@
+import streamlit as st
+import pandas as pd
+import plotly.graph_objects as go
+import plotly.express as px
+from src.constants import COLOR_SCHEME
+import pdb
+
+
+class NullReport:
+    def __init__(self, data, v1, v2, v3, condo, mapped):
+        self.df_null = data
+        self.v1 = v1
+        self.v2 = v2
+        self.v3 = v3
+        self.condo = condo
+        self.mapped = mapped
+
+    def __call__(self):
+        st.subheader("Null Graph")
+        x = [
+            "borough",
+            "block",
+            "lot",
+            "cd",
+            # "bct2020",
+            # "bctcb2020",
+            "ct2010",
+            "cb2010",
+            "schooldist",
+            "council",
+            "zipcode",
+            "firecomp",
+            "policeprct",
+            "healtharea",
+            "sanitboro",
+            "sanitsub",
+            "address",
+            "zonedist1",
+            "zonedist2",
+            "zonedist3",
+            "zonedist4",
+            "overlay1",
+            "overlay2",
+            "spdist1",
+            "spdist2",
+            "spdist3",
+            "ltdheight",
+            "splitzone",
+            "bldgclass",
+            "landuse",
+            "easements",
+            "ownertype",
+            "ownername",
+            "lotarea",
+            "bldgarea",
+            "comarea",
+            "resarea",
+            "officearea",
+            "retailarea",
+            "garagearea",
+            "strgearea",
+            "factryarea",
+            "otherarea",
+            "areasource",
+            "numbldgs",
+            "numfloors",
+            "unitsres",
+            "unitstotal",
+            "lotfront",
+            "lotdepth",
+            "bldgfront",
+            "bldgdepth",
+            "ext",
+            "proxcode",
+            "irrlotcode",
+            "lottype",
+            "bsmtcode",
+            "assessland",
+            "assesstot",
+            "exempttot",
+            "yearbuilt",
+            "yearalter1",
+            "yearalter2",
+            "histdist",
+            "landmark",
+            "builtfar",
+            "residfar",
+            "commfar",
+            "facilfar",
+            "borocode",
+            "bbl",
+            "condono",
+            "tract2010",
+            "xcoord",
+            "ycoord",
+            "longitude",
+            "latitude",
+            "zonemap",
+            "zmcode",
+            "sanborn",
+            "taxmap",
+            "edesignum",
+            "appbbl",
+            "appdate",
+            "plutomapid",
+            "version",
+            "sanitdistrict",
+            "healthcenterdistrict",
+            "firm07_flag",
+            "pfirm15_flag",
+        ]
+
+        field_range = st.slider(
+            "Select a range of values",
+            min_value=0,
+            max_value=len(x),
+            value=[0, 12],
+        )
+
+        df = self.df_null
+        df = df.loc[
+            (df.condo == self.condo)
+            & (df.mapped == self.mapped)
+            & (df.pair.isin([f"{self.v1} - {self.v2}", f"{self.v2} - {self.v3}"])),
+            :,
+        ].drop_duplicates()
+
+        df_transformed = df.drop(columns=["condo", "mapped", "total"])
+        df_transformed = self.sort_and_filter_df(df_transformed, field_range)
+
+        v1v2 = f"{self.v1} - {self.v2}" in df_transformed.version.unique()
+        v2v3 = f"{self.v2} - {self.v3}" in df_transformed.version.unique()
+
+        if not (v1v2 or v2v3):
+            st.write("Null Graph")
+            st.info("There is no change in NULL values across three versions.")
+            return
+        if v1v2 and not v2v3:
+            self.display_graph(df_transformed, field_range, False)
+        elif v2v3 and not v1v2:
+            self.display_graph(df_transformed, field_range, False)
+        else:
+            self.display_graph(df_transformed, field_range, True)
+
+        st.info(
+            """
+                The above graph highlights records that formerly had a value and are now NULL, or vice versa.
+                The number records going from NULL to not NULL or vice versa should be small for any field.
+            """
+        )
+        st.write(df)
+
+    def sort_and_filter_df(self, df, range):
+        df = df[["pair"] + df.columns.tolist()[range[0] + 1 : range[1] + 1]]
+        df_transformed = (
+            df.set_index("pair")
+            .stack()
+            .reset_index()
+            .rename(columns={"pair": "version", "level_1": "field", 0: "change"})
+            .sort_values(by="change", ascending=False)
+        )
+        return df_transformed
+
+    def display_graph(self, df_transformed, range, grouped=True):
+        if grouped:
+            fig1 = px.bar(
+                data_frame=df_transformed,
+                y="change",
+                x="field",
+                barmode="group",
+                color="version",
+                color_discrete_sequence=COLOR_SCHEME,
+                height=400,
+                width=850,
+                text_auto=True,
+                title="Null Graph",
+            )
+            fig1.update_layout(legend_title_text="Version")
+        else:
+            fig1 = px.bar(
+                data_frame=df_transformed,
+                y="change",
+                x="field",
+                color_discrete_sequence=COLOR_SCHEME,
+                height=400,
+                width=850,
+                text_auto=True,
+                title="Null Graph",
+            )
+        fig1.update_xaxes(title="Field")
+        fig1.update_yaxes(title="Change in Null")
+
+        st.plotly_chart(fig1)

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -9,10 +9,18 @@ def pluto():
     import requests
     from src.pluto.helpers import get_branches, get_data
     from st_aggrid import AgGrid
+    from numerize.numerize import numerize
+
     from src.constants import COLOR_SCHEME
     from src.pluto.components.corrections_report import CorrectionsReport
+    from src.pluto.components.mismatch_report import MismatchReport
     from src.pluto.components.null_graph import NullReport
-    from numerize.numerize import numerize
+    from src.pluto.components.source_data_versions_report import (
+        SourceDataVersionsReport,
+    )
+    from src.pluto.components.expected_value_differences_report import (
+        ExpectedValueDifferencesReport,
+    )
 
     st.title("PLUTO QAQC")
     st.markdown(
@@ -75,232 +83,15 @@ def pluto():
             The graphs report the number of records that have a different value in a given field but share the same BBL between versions. \
             For example, you can read these graphs as "there are 300,000 records with the same BBL between {v1} to {v2}, but the exempttot value changed." \
             The graphs are useful to see if there are any dramatic changes in the values of fields between versions.
-
             There is an option to filter these graphs to just show condo lots. \
             Condos make up a small percentage of all lots, but they contain a large percentage of the residential housing. \
             A second filter enables you look at all lots or just mapped lots. \
             Unmapped lots are those with a record in PTS, but no corresponding record in DTM. \
             This happens because DOF updates are not in sync.
-
             In this series of graphs the x-axis is the field name and the y-axis is the total number of records. \
             Hover over the graph to see the percent of records that have a change.
         """
         )
-        # test
-        def create_mismatch(df_mismatch, v1, v2, v3, condo, mapped):
-            finance_columns = [
-                "assessland",
-                "assesstot",
-                "exempttot",
-                "taxmap",
-                "appbbl",
-                "appdate",
-                "plutomapid",
-            ]
-
-            area_columns = [
-                "lotarea",
-                "bldgarea",
-                "builtfar",
-                "comarea",
-                "resarea",
-                "officearea",
-                "retailarea",
-                "garagearea",
-                "strgearea",
-                "factryarea",
-                "otherarea",
-                "areasource",
-            ]
-
-            zoning_columns = [
-                "residfar",
-                "commfar",
-                "facilfar",
-                "zonedist1",
-                "zonedist2",
-                "zonedist3",
-                "zonedist4",
-                "overlay1",
-                "overlay2",
-                "spdist1",
-                "spdist2",
-                "spdist3",
-                "ltdheight",
-                "splitzone",
-                "zonemap",
-                "zmcode",
-                "edesignum",
-            ]
-
-            geo_columns = [
-                "cd",
-                # "bct2020",
-                # "bctcb2020",
-                "ct2010",
-                "cb2010",
-                "schooldist",
-                "council",
-                "zipcode",
-                "firecomp",
-                "policeprct",
-                "healtharea",
-                "sanitboro",
-                "sanitsub",
-                "address",
-                "borocode",
-                "bbl",
-                "tract2010",
-                "xcoord",
-                "ycoord",
-                "longitude",
-                "latitude",
-                "sanborn",
-                "edesignum",
-                "sanitdistrict",
-                "healthcenterdistrict",
-                "histdist",
-                "firm07_flag",
-                "pfirm15_flag",
-            ]
-            ab = ["a", "b", "c"]
-            av = ["a", "b", "c"]
-
-            ac = ["a", "b", "c"]
-
-            ad = ["a", "b", "c"]
-
-            bldg_columns = [
-                "bldgclass",
-                "landuse",
-                "easements",
-                "ownertype",
-                "ownername",
-                "numbldgs",
-                "numfloors",
-                "unitsres",
-                "unitstotal",
-                "lotfront",
-                "lotdepth",
-                "bldgfront",
-                "bldgdepth",
-                "ext",
-                "proxcode",
-                "irrlotcode",
-                "lottype",
-                "bsmtcode",
-                "yearbuilt",
-                "yearalter1",
-                "yearalter2",
-                "landmark",
-                "condono",
-            ]
-
-            groups = [
-                {
-                    "title": "Mismatch graph -- finance fields",
-                    "columns": finance_columns,
-                    "description": """
-                        DOF updates the assessment and exempt values twice a year. 
-                        The tentative tax roll is released in mid-January and the final tax roll is released in late May. 
-                        We expect the values of the fields in the above graph to change in versions of PLUTO created after the release of the tentative or final roll. 
-                        For the PLUTO version created right after the tentative roll, most lots will show a change in assesstot, with a smaller number of changes for the assessland and exempttot.
-                        There will also be changes to these fields in the version created after the release of the final roll. 
-                        Versions created between roll releases should see almost no change for these fields.
-                    """,
-                },
-                {
-                    "title": "Mismatch graph -- area fields",
-                    "columns": area_columns,
-                    "description": """
-                        CAMA is the primary source for the area fields. Updates reflect new construction, as well as updates by assessors for the tentative roll. 
-                        Several thousand lots may have updates in the version created after the tentative tax roll.
-                    """,
-                },
-                {
-                    "title": "Mismatch graph -- zoning fields",
-                    "columns": zoning_columns,
-                    "description": """
-                    Unless DCP does a major rezoning, the number of lots with changed values should be **no more than a couple of hundred**.
-                    Lots may get a changed value due to a split/merge or if TRD is cleaning up boundaries between zoning districts.
-                    `Residfar`, `commfar`, and `facilfar` should change only when there is a change to `zonedist1` or `overlay1`.
-                """,
-                },
-                {
-                    "title": "Mismatch graph -- geo fields",
-                    "columns": geo_columns,
-                    "description": """
-                    These fields are updated from **Geosupport**. Changes should be minimal unless a municipal service
-                    area changes or more high-rise buildings opt into the composite recycling program.
-                    Check with GRU if more than a small number of lots have changes to municipal service areas.
-                """,
-                },
-                {
-                    "title": "Mismatch graph -- building fields",
-                    "columns": bldg_columns,
-                    "description": """
-                        Changes in these fields are most common after the tentative roll has been released. 
-                        Several fields in this group are changed by DCP to improve data quality, including ownername and yearbuilt. 
-                        When these changes are first applied, there will be a spike in the number of lots changed.
-                    """,
-                },
-            ]
-
-            df = df_mismatch.loc[
-                (df_mismatch.condo == condo)
-                & (df_mismatch.mapped == mapped)
-                & (df_mismatch.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
-                :,
-            ]
-
-            v1v2 = df.loc[df.pair == f"{v1} - {v2}", :].to_dict("records")[0]
-            v2v3 = df.loc[df.pair == f"{v2} - {v3}", :].to_dict("records")[0]
-            v1v2_total = v1v2.pop("total")
-            v2v3_total = v2v3.pop("total")
-
-            def generate_graph_data(r, total, name, group):
-                r = {key: value for (key, value) in r.items() if key in group}
-                y = [r[i] for i in group]
-                x = group
-                hovertemplate = "<b>%{x} %{text}</b>"
-                text = [f"{round(r[i]/total*100, 2)}%" for i in group]
-                return go.Scatter(
-                    x=x,
-                    y=y,
-                    mode="lines",
-                    name=name,
-                    hovertemplate=hovertemplate,
-                    text=text,
-                )
-
-            def generate_graph(v1v2, v2v3, v1v2_total, v2v3_total, group):
-                fig = go.Figure()
-                fig.add_trace(
-                    generate_graph_data(v1v2, v1v2_total, v1v2["pair"], group)
-                )
-                fig.add_trace(
-                    generate_graph_data(v2v3, v2v3_total, v2v3["pair"], group)
-                )
-                return fig
-
-            for group in groups:
-                fig = generate_graph(
-                    v1v2, v2v3, v1v2_total, v2v3_total, group["columns"]
-                )
-                fig.update_layout(
-                    title=group["title"], template="plotly_white", colorway=COLOR_SCHEME
-                )
-                st.plotly_chart(fig)
-                st.info(group["description"])
-
-            st.subheader("Summary of Differences by Field")
-            st.write(df)
-            st.info(
-                """
-                This table reports the number of records with differences in a field value between versions. 
-                This table is useful for digging into any anomalies identified using the graphs above.
-            """
-            )
 
         def create_aggregate(df_aggregate, v1, v2, v3, condo, mapped):
             df = df_aggregate.loc[
@@ -378,50 +169,10 @@ def pluto():
                 The aggregate graph may show that the aggregated sum increased by 5%. 
                 Totals for assessland, assesstot, and exempttot should only change after the tentative and final rolls. 
                 Pay attention to any large changes to residential units (unitsres).
-
                 The graph shows the percent increase or decrease in the sum of the field between version. 
                 The table reports the raw numbers for more in depth analysis.
             """
             )
-
-        def create_expected(df, v1, v2):
-
-            exp = df[df["v"].isin([v1, v2])]
-
-            exp_records = exp.to_dict("records")
-            v1_exp = [i["expected"] for i in exp_records if i["v"] == v1][0]
-            v2_exp = [i["expected"] for i in exp_records if i["v"] == v2][0]
-            for field in [
-                "zonedist1",
-                "zonedist2",
-                "zonedist3",
-                "zonedist4",
-                "overlay1",
-                "overlay2",
-                "spdist1",
-                "spdist2",
-                "spdist3",
-                "ext",
-                "proxcode",
-                "irrlotcode",
-                "lottype",
-                "bsmtcode",
-                "bldgclasslanduse",
-            ]:
-                val1 = [i["values"] for i in v1_exp if i["field"] == field][0]
-                val2 = [i["values"] for i in v2_exp if i["field"] == field][0]
-                in1not2 = [i for i in val1 if i not in val2]
-                in2not1 = [i for i in val2 if i not in val1]
-                if len(in1not2) == 0 and len(in2not1) == 0:
-                    pass
-                else:
-                    st.markdown(f"### Expected value difference for {field}")
-                    if len(in1not2) != 0:
-                        st.markdown(f"* in {v1} but not in {v2}:")
-                        st.write(in1not2)
-                    if len(in2not1) != 0:
-                        st.markdown(f"* in {v2} but not in {v1}:")
-                        st.write(in2not1)
 
         def create_outlier(df, v1, v2, condo, mapped):
             versions = df.v.unique()
@@ -478,7 +229,9 @@ def pluto():
 
             display_dataframe(v1_outlier, "lotarea_numfloor")
 
-        create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
+        MismatchReport(
+            data=data["df_mismatch"], v1=v1, v2=v2, v3=v3, condo=condo, mapped=mapped
+        )()
 
         create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
 
@@ -486,24 +239,9 @@ def pluto():
             data=data["df_null"], v1=v1, v2=v2, v3=v3, condo=condo, mapped=mapped
         )()
 
-        st.header("Source Data Versions")
-        code = st.checkbox("code")
-        if code:
-            st.code(data["version_text"])
-        else:
-            st.markdown(data["version_text"])
+        SourceDataVersionsReport(version_text=data["version_text"])()
 
-        # EXPECTED VALUE
-        st.header("Expected Value Comparison")
-        st.write(
-            """
-            For some fields we report the expected values and descriptions in appendixes of the ReadMe document. 
-            Therefore, it's important for us to know when new values are added to field or a value is no longer present in a field. 
-            If the below is blank, that means that there are no changes in the values in selected fields between the selected and previous version.
-        """
-        )
-
-        create_expected(data["df_expected"], v1, v2)
+        ExpectedValueDifferencesReport(data=data["df_expected"], v1=v1, v2=v2)()
 
         # OUTLIER VALUE
         st.header("OUTLIER ANALYSIS")

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -480,11 +480,11 @@ def pluto():
 
         create_mismatch(data["df_mismatch"], v1, v2, v3, condo, mapped)
 
+        create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
+
         NullReport(
             data=data["df_null"], v1=v1, v2=v2, v3=v3, condo=condo, mapped=mapped
         )()
-
-        create_aggregate(data["df_aggregate"], v1, v2, v3, condo, mapped)
 
         st.header("Source Data Versions")
         code = st.checkbox("code")

--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -302,10 +302,10 @@ def pluto():
             )
 
         def create_null(df_null, v1, v2, v3, condo, mapped):
+            excluded = df_null.loc[:, (df_null == 0).all()].columns.to_list()
+            excluded.remove('zonedist4')
+            excluded.remove('spdist3')
             x = [
-                "borough",
-                "block",
-                "lot",
                 "cd",
                 # "bct2020",
                 # "bctcb2020",
@@ -369,11 +369,6 @@ def pluto():
                 "histdist",
                 "landmark",
                 "builtfar",
-                "residfar",
-                "commfar",
-                "facilfar",
-                "borocode",
-                "bbl",
                 "condono",
                 "tract2010",
                 "xcoord",
@@ -387,8 +382,6 @@ def pluto():
                 "edesignum",
                 "appbbl",
                 "appdate",
-                "plutomapid",
-                "version",
                 "sanitdistrict",
                 "healthcenterdistrict",
                 "firm07_flag",
@@ -413,6 +406,7 @@ def pluto():
                 & (df_null.pair.isin([f"{v1} - {v2}", f"{v2} - {v3}"])),
                 :,
             ].drop_duplicates()
+            df = df.loc[:, ~df.columns.isin(excluded)]
 
             v1v2 = df.loc[df_null.pair == f"{v1} - {v2}", :]
             v2v3 = df.loc[df_null.pair == f"{v2} - {v3}", :]
@@ -434,6 +428,7 @@ def pluto():
             fig.update_layout(
                 title="Null graph", template="plotly_white", colorway=COLOR_SCHEME
             )
+            
             st.plotly_chart(fig)
             st.info(
                 """


### PR DESCRIPTION
Addresses the issue [here](https://github.com/NYCPlanning/data-engineering-qaqc/issues/188). 

As Amanda points out, we want to limit the graph to report fields where NULL is a value in the field. I checked the PLUTO data, and discovered that borough, block, lot, residfar, commfar, facilfar, borocode, bbl, plutomapid, and version do not have null values. And I assume these fields won't have a NULL value in it in any version (correct me if I am wrong). As for zonedist4 and spdist3, although there is no change of null counts for these two fields, we should still display them as NULL always exists. I think modifying the displayed fields manually may be the most convenient way. 