### PR TITLE
Update cpdb bucket to `edm-publishing`

### DIFF
--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -6,7 +6,7 @@ from src.digital_ocean_client import DigitalOceanClient
 load_dotenv()
 
 
-BUCKET_NAME = "edm-private"
+BUCKET_NAME = "edm-publishing"
 REPO_NAME = "db-cpdb"
 
 VIZKEY = {

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -46,19 +46,15 @@ def get_data(branch) -> dict:
     client = digital_ocean_client()
 
     for t in tables["analysis"]:
-        rv[t] = client.csv_from_DO(
-            url=f"db-cpdb/{branch}/latest/output/analysis/{t}.csv"
-        )
+        rv[t] = client.csv_from_DO(url=construct_url(branch, t, sub_folder="analysis/"))
         rv["pre_" + t] = client.csv_from_DO(
-            url=f"db-cpdb/main/2022-04-15/output/analysis/{t}.csv"
+            url=construct_url("main", t, "2022-04-15", sub_folder="analysis/")
         )
     for t in tables["others"]:
-        rv[t] = client.csv_from_DO(url=f"db-cpdb/{branch}/latest/output/{t}.csv")
-        rv["pre_" + t] = client.csv_from_DO(
-            url=f"db-cpdb/main/2022-04-15/output/{t}.csv"
-        )
+        rv[t] = client.csv_from_DO(url=construct_url(branch, t))
+        rv["pre_" + t] = client.csv_from_DO(url=construct_url("main", t, "2022-04-15"))
     for t in tables["no_version_compare"]:
-        rv[t] = client.csv_from_DO(url=f"db-cpdb/{branch}/latest/output/{t}.csv")
+        rv[t] = client.csv_from_DO(url=construct_url(branch, t))
     for t in tables["geometries"]:
         rv[t] = get_geometries(branch, table=t)
     print(rv.keys())
@@ -100,6 +96,13 @@ def sort_base_on_option(
     )
 
     return df_sort
+
+
+def construct_url(branch, table, build="latest", sub_folder=""):
+    return (
+        f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-cpdb/{branch}"
+        f"/{build}/output/{sub_folder}{table}.csv"
+    )
 
 
 def digital_ocean_client():


### PR DESCRIPTION
This upgrade was harder than expected for two reasons. 

The first is that the existing `cpdb_helpers.py` was not DRY. It relied on a lot of copied/pasted code that I hope I cleaned up. 

The second is that the digital ocean client uses two different approaches to download files based on whether the bucket is public or private. There is a good reason for it to be written this way, that's my fault for not reading closely. 

### New solution
A url like `https://edm-publishing.nyc3.digitaloceanspaces.com/<etc>` in constructed like in helper file for devDB. 

### Future work

One pressing upgrade is that the path to the previous version is hardcoded! This is a bug, something we overlooked originally. I wrote it up in issue #236

The potential enhancement is to DRY out the code that sets the URL. I wrote this issue up in #237