### PR TITLE
Create Drop Down Menu to Pick Previous Version Dynamically 

### DIFF
--- a/src/cpdb/cpdb.py
+++ b/src/cpdb/cpdb.py
@@ -8,6 +8,7 @@ from src.cpdb.helpers import (
     get_map_percent_diff,
     sort_base_on_option,
     VIZKEY,
+    cpdb_published_version,
 )
 import plotly.express as px
 import plotly.graph_objects as go
@@ -22,6 +23,10 @@ from src.cpdb.components.withinNYC_check import withinNYC_check
 def cpdb():
     st.title("Capital Projects Database QAQC")
     branch = st.sidebar.selectbox("select a branch", ["main"])
+    build = st.sidebar.selectbox(
+        "Pick a published version of CPDB to compare with latest (by date):",
+        cpdb_published_version,
+    )
     agency_label = {"sagency": "Sponsoring Agency", "magency": "Managing Agency"}
     agency_type = st.sidebar.selectbox(
         "select an agency type",
@@ -43,7 +48,7 @@ def cpdb():
         "choose a subcategory or entire portfolio", ["all categories", "fixed assets"]
     )
 
-    data = get_data(branch=branch)
+    data = get_data(branch, build)
 
     st.markdown(
         body="""

--- a/src/cpdb/cpdb.py
+++ b/src/cpdb/cpdb.py
@@ -8,7 +8,7 @@ from src.cpdb.helpers import (
     get_map_percent_diff,
     sort_base_on_option,
     VIZKEY,
-    cpdb_published_version,
+    cpdb_published_versions,
 )
 import plotly.express as px
 import plotly.graph_objects as go
@@ -23,9 +23,9 @@ from src.cpdb.components.withinNYC_check import withinNYC_check
 def cpdb():
     st.title("Capital Projects Database QAQC")
     branch = st.sidebar.selectbox("select a branch", ["main"])
-    build = st.sidebar.selectbox(
+    previous_version = st.sidebar.selectbox(
         "Pick a published version of CPDB to compare with latest (by date):",
-        cpdb_published_version,
+        cpdb_published_versions,
     )
     agency_label = {"sagency": "Sponsoring Agency", "magency": "Managing Agency"}
     agency_type = st.sidebar.selectbox(
@@ -48,7 +48,7 @@ def cpdb():
         "choose a subcategory or entire portfolio", ["all categories", "fixed assets"]
     )
 
-    data = get_data(branch, build)
+    data = get_data(branch, previous_version)
 
     st.markdown(
         body="""

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -1,9 +1,16 @@
+from distutils.command.build import build
 import pandas as pd
 from dotenv import load_dotenv
 import geopandas as gpd
 from src.digital_ocean_client import DigitalOceanClient
 
 load_dotenv()
+
+cpdb_published_version = [
+    "2022-10-25",  # '22 CPDB Adopted
+    "2022-06-08",  # '22 CPDB Executive
+    "2022-04-15",  # '22 CPDB Prelminary
+]
 
 
 BUCKET_NAME = "edm-publishing"
@@ -34,7 +41,7 @@ def get_geometries(branch, table) -> dict:
     return gdf
 
 
-def get_data(branch) -> dict:
+def get_data(branch, build) -> dict:
     rv = {}
     tables = {
         "analysis": ["cpdb_summarystats_sagency", "cpdb_summarystats_magency"],
@@ -48,11 +55,11 @@ def get_data(branch) -> dict:
     for t in tables["analysis"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t, sub_folder="analysis/"))
         rv["pre_" + t] = client.csv_from_DO(
-            url=construct_url("main", t, "2022-04-15", sub_folder="analysis/")
+            url=construct_url(branch, t, build, sub_folder="analysis/")
         )
     for t in tables["others"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t))
-        rv["pre_" + t] = client.csv_from_DO(url=construct_url("main", t, "2022-04-15"))
+        rv["pre_" + t] = client.csv_from_DO(url=construct_url(branch, t, build))
     for t in tables["no_version_compare"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t))
     for t in tables["geometries"]:

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -40,7 +40,7 @@ def get_geometries(branch, table) -> dict:
     return gdf
 
 
-def get_data(branch, build) -> dict:
+def get_data(branch, previous_version) -> dict:
     rv = {}
     tables = {
         "analysis": ["cpdb_summarystats_sagency", "cpdb_summarystats_magency"],
@@ -54,11 +54,13 @@ def get_data(branch, build) -> dict:
     for t in tables["analysis"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t, sub_folder="analysis/"))
         rv["pre_" + t] = client.csv_from_DO(
-            url=construct_url(branch, t, build, sub_folder="analysis/")
+            url=construct_url(branch, t, previous_version, sub_folder="analysis/")
         )
     for t in tables["others"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t))
-        rv["pre_" + t] = client.csv_from_DO(url=construct_url(branch, t, build))
+        rv["pre_" + t] = client.csv_from_DO(
+            url=construct_url(branch, t, previous_version)
+        )
     for t in tables["no_version_compare"]:
         rv[t] = client.csv_from_DO(url=construct_url(branch, t))
     for t in tables["geometries"]:

--- a/src/cpdb/helpers.py
+++ b/src/cpdb/helpers.py
@@ -1,4 +1,3 @@
-from distutils.command.build import build
 import pandas as pd
 from dotenv import load_dotenv
 import geopandas as gpd
@@ -6,7 +5,7 @@ from src.digital_ocean_client import DigitalOceanClient
 
 load_dotenv()
 
-cpdb_published_version = [
+cpdb_published_versions = [
     "2022-10-25",  # '22 CPDB Adopted
     "2022-06-08",  # '22 CPDB Executive
     "2022-04-15",  # '22 CPDB Prelminary


### PR DESCRIPTION
Addresses issue #239 scoped out by Sasha. Small PR - one reviewer ⭐ 

CPDB version's were previously set by hardcoding in the previous version but this makes it very difficult to maintain and users aren't able to confirm which version is set as `previous`. To rectify this, I created a drop down menu that allows the user to set the `previous` version (with the default being `latest` therefore you won't see any difference counts in the graphs unless you choose a different `previous` version). I chose to only include published version of CPDB (`2022-10-25 AKA 22_adopted`, `20202-06-08 AKA 22_executive`, `2022-04-08 AKA 22_preliminary`) because these are the version of most interest for EDM and to avoid any confusion for other teams who might use the app.

**NOTE**

CPDB folder naming structure might need to change at some point. Currently, its difficult to know which version of CPDB is a published version (sent to Capital Planning -> QAQC'd -> approved by CP -> sent to OSE -> published on CPE). I think we should think about how we want to keep our published version of cpdb separate from other builds of cpdb on `main`. As of now, I had to look through emails to identify which versions of cpdb are published and that makes it  difficult to trace which version of CPDB are published vs. others.