### PR TITLE
Add Minor Version of Pluto to App Page

### DIFF
--- a/src/pluto/pluto.py
+++ b/src/pluto/pluto.py
@@ -47,6 +47,7 @@ def pluto():
 
     def version_comparison_report(data):
         versions = [
+            "22v3.1",
             "22v3",
             "22v2",
             "22v1",


### PR DESCRIPTION
Addresses issue #247.

Add 22v3.1 to PLUTO page - the new minor version of pluto that will be released monthly.

Future work
Think about how we want to compare minor versions vs major versions of PLUTO in the app 