### PR TITLE
standardize branch options for DevDB and FacDB

### DIFF
--- a/src/devdb/devdb.py
+++ b/src/devdb/devdb.py
@@ -3,11 +3,8 @@ from src.devdb.components.field_distribution_report import FieldDistributionRepo
 
 def devdb():
     import streamlit as st
-    import pandas as pd
-    import numpy as np
-    import os
-    import pdb
-    from src.devdb.helpers import get_data, QAQC_CHECK_DICTIONARY, QAQC_CHECK_SECTIONS
+    from src.report_utils import get_active_s3_folders
+    from src.devdb.helpers import get_latest_data, REPO_NAME, BUCKET_NAME, QAQC_CHECK_DICTIONARY, QAQC_CHECK_SECTIONS
     from src.devdb.components.flagged_jobs_report import FlaggedJobsReport
     from src.devdb.components.qaqc_version_history_report import (
         QAQCVersionHistoryReport,
@@ -36,9 +33,13 @@ def devdb():
         """
     )
 
-    branch = st.sidebar.selectbox("select a branch", ["dev", "main"])
+    branches = get_active_s3_folders(repo=REPO_NAME, bucket_name=BUCKET_NAME)
+    branch = st.sidebar.selectbox(
+        "select a branch",
+        branches,
+    )
 
-    data = get_data(branch)
+    data = get_latest_data(branch)
 
     QAQCVersionHistoryReport(
         data=data,

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -170,7 +170,7 @@ QAQC_CHECK_DICTIONARY = {
 }
 
 
-def get_data(branch):
+def get_latest_data(branch):
     rv = {}
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
 

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -3,7 +3,10 @@ from typing import Dict
 from urllib.error import HTTPError
 import streamlit as st
 import json
-from src.digital_ocean_utils import DigitalOceanClient
+from src.digital_ocean_utils import (
+    DigitalOceanClient,
+    construct_branch_output_data_directory_url,
+)
 
 BUCKET_NAME = "edm-publishing"
 REPO_NAME = "db-developments"
@@ -170,9 +173,14 @@ QAQC_CHECK_DICTIONARY = {
 }
 
 
-def get_latest_data(branch):
+def get_latest_data(branch) -> dict[str, pd.DataFrame]:
     rv = {}
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
+    # url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
+    url = construct_branch_output_data_directory_url(
+        dataset=REPO_NAME,
+        branch=branch,
+        version="latest",
+    )
 
     client = DigitalOceanClient(bucket_name=BUCKET_NAME, repo_name=REPO_NAME)
 

--- a/src/devdb/helpers.py
+++ b/src/devdb/helpers.py
@@ -175,7 +175,6 @@ QAQC_CHECK_DICTIONARY = {
 
 def get_latest_data(branch) -> dict[str, pd.DataFrame]:
     rv = {}
-    # url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/{branch}/latest/output"
     url = construct_branch_output_data_directory_url(
         dataset=REPO_NAME,
         branch=branch,

--- a/src/digital_ocean_utils.py
+++ b/src/digital_ocean_utils.py
@@ -19,6 +19,10 @@ construct_data_library_config_url = lambda dataset, version: (
     f"https://edm-recipes.nyc3.cdn.digitaloceanspaces.com/datasets/{dataset}/{version}/config.json"
 )
 
+construct_branch_output_data_directory_url = lambda dataset, branch, version: (
+    f"https://edm-publishing.nyc3.digitaloceanspaces.com/{dataset}/{branch}/{version}/output"
+)
+
 construct_output_data_directory_url = lambda dataset, version: (
     f"https://edm-publishing.nyc3.digitaloceanspaces.com/{dataset}/{version}/output/"
 )

--- a/src/digital_ocean_utils.py
+++ b/src/digital_ocean_utils.py
@@ -24,7 +24,7 @@ construct_branch_output_data_directory_url = lambda dataset, branch, version: (
 )
 
 construct_output_data_directory_url = lambda dataset, version: (
-    f"https://edm-publishing.nyc3.digitaloceanspaces.com/{dataset}/{version}/output/"
+    f"https://edm-publishing.nyc3.digitaloceanspaces.com/{dataset}/{version}/output"
 )
 
 load_dotenv()
@@ -40,7 +40,7 @@ def get_datatset_config(dataset: str, version: str) -> dict:
 def get_latest_build_version(dataset: str) -> str:
     # TODO handle lack of version file
     version = requests.get(
-        f"{construct_output_data_directory_url(dataset=dataset, version='latest')}version.txt",
+        f"{construct_output_data_directory_url(dataset=dataset, version='latest')}/version.txt",
         timeout=10,
     ).text
     return version

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -6,6 +6,7 @@ import plotly.graph_objects as go  # type: ignore
 import plotly.express as px  # type: ignore
 import requests
 from src.facdb.helpers import get_data, remove_branches
+from src.github import get_branches
 from src.constants import COLOR_SCHEME
 
 
@@ -38,14 +39,6 @@ def facdb():
             colorway=COLOR_SCHEME,
         )
         st.plotly_chart(fig)
-
-    def get_branches():
-        url = "https://api.github.com/repos/nycplanning/db-facilities/branches"
-        response = requests.get(url).json()
-        all_branches = [r["name"] for r in response]
-        return [
-            b for b in all_branches if b not in remove_branches
-        ]  # filter branches no longer needed in qaqc
 
     branches = get_branches()
     branch = st.sidebar.selectbox(

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -6,10 +6,7 @@ import plotly.graph_objects as go  # type: ignore
 import plotly.express as px  # type: ignore
 from src.constants import COLOR_SCHEME
 from src.report_utils import get_active_s3_folders
-from src.facdb.helpers import get_latest_data
-
-BUCKET_NAME = "edm-publishing"
-REPO_NAME = "db-facilities"
+from src.facdb.helpers import get_latest_data, REPO_NAME, BUCKET_NAME
 
 def facdb():
     st.title("Facilities DB QAQC")

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -4,10 +4,12 @@ import numpy as np
 import pydeck as pdk  # type: ignore
 import plotly.graph_objects as go  # type: ignore
 import plotly.express as px  # type: ignore
-import requests
-from src.facdb.helpers import get_latest_data, get_active_s3_folders
 from src.constants import COLOR_SCHEME
+from src.report_utils import get_active_s3_folders
+from src.facdb.helpers import get_latest_data
 
+BUCKET_NAME = "edm-publishing"
+REPO_NAME = "db-facilities"
 
 def facdb():
     st.title("Facilities DB QAQC")
@@ -39,7 +41,7 @@ def facdb():
         )
         st.plotly_chart(fig)
 
-    branches = get_active_s3_folders()
+    branches = get_active_s3_folders(repo=REPO_NAME, bucket_name=BUCKET_NAME)
     branch = st.sidebar.selectbox(
         "select a branch",
         branches,

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -43,7 +43,6 @@ def facdb():
     branch = st.sidebar.selectbox(
         "select a branch",
         branches,
-        index=branches.index("develop"),
     )
     if st.sidebar.button(
         label="Refresh data", help="Download newest files from Digital Ocean"

--- a/src/facdb/facdb.py
+++ b/src/facdb/facdb.py
@@ -5,8 +5,7 @@ import pydeck as pdk  # type: ignore
 import plotly.graph_objects as go  # type: ignore
 import plotly.express as px  # type: ignore
 import requests
-from src.facdb.helpers import get_data, remove_branches
-from src.github import get_branches
+from src.facdb.helpers import get_latest_data, get_active_s3_folders
 from src.constants import COLOR_SCHEME
 
 
@@ -40,7 +39,7 @@ def facdb():
         )
         st.plotly_chart(fig)
 
-    branches = get_branches()
+    branches = get_active_s3_folders()
     branch = st.sidebar.selectbox(
         "select a branch",
         branches,
@@ -51,7 +50,7 @@ def facdb():
     ):
 
         st.cache_data.clear()
-        get_data(branch)
+        get_latest_data(branch)
 
     general_or_classification = st.sidebar.selectbox(
         "Would you like to review general QAQC or changes by classification?",
@@ -59,7 +58,7 @@ def facdb():
     )
     st.subheader(general_or_classification)
 
-    qc_tables, qc_diff, qc_mapped = get_data(branch)
+    qc_tables, qc_diff, qc_mapped = get_latest_data(branch)
 
     def count_comparison(df, width=1000, height=1000):
         fig = go.Figure()

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -1,9 +1,19 @@
 import streamlit as st
 import pandas as pd
+from src.digital_ocean_utils import construct_branch_output_data_directory_url
 
+BUCKET_NAME = "edm-publishing"
+REPO_NAME = "db-facilities"
 
-def get_latest_data(branch):
-    url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-facilities/{branch}/latest/output"
+def get_latest_data(
+    branch,
+) -> tuple[dict[str, dict[str, pd.DataFrame | str]], pd.DataFrame, pd.DataFrame]:
+    url = construct_branch_output_data_directory_url(
+        dataset=REPO_NAME,
+        branch=branch,
+        version="latest",
+    )
+    
     qc_diff = pd.read_csv(f"{url}/qc_diff.csv")
     qc_captype = pd.read_csv(f"{url}/qc_captype.csv")
     qc_classification = pd.read_csv(f"{url}/qc_classification.csv")
@@ -16,8 +26,17 @@ def get_latest_data(branch):
             "dataframe": qc_classification,
             "type": "dataframe",
         },
-        "Operator": {"dataframe": qc_operator, "type": "dataframe"},
-        "Oversight": {"dataframe": qc_oversight, "type": "dataframe"},
-        "Capacity Types": {"dataframe": qc_captype, "type": "table"},
+        "Operator": {
+            "dataframe": qc_operator,
+            "type": "dataframe",
+        },
+        "Oversight": {
+            "dataframe": qc_oversight,
+            "type": "dataframe",
+        },
+        "Capacity Types": {
+            "dataframe": qc_captype,
+            "type": "table",
+        },
     }
     return qc_tables, qc_diff, qc_mapped

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -1,18 +1,21 @@
 import streamlit as st
 import pandas as pd
 from src.digital_ocean_utils import DigitalOceanClient
-from src.github import get_branches
+from src.github import get_default_branch, get_branches
 
 BUCKET_NAME = "edm-publishing"
 REPO_NAME = "db-facilities"
 
 def get_active_s3_folders():
+    default_branch = get_default_branch(repo=REPO_NAME)
     all_branches = get_branches(repo=REPO_NAME, branches_blacklist=[])
     all_folders = DigitalOceanClient(
         bucket_name=BUCKET_NAME, repo_name=REPO_NAME,
     ).get_all_folder_names_in_repo_folder()
 
     folders = sorted(list(set(all_folders).intersection(set(all_branches))))
+    folders.remove(default_branch)
+    folders = [default_branch] + folders
     return folders
 
 def get_latest_data(branch):

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -1,33 +1,21 @@
 import streamlit as st
 import pandas as pd
+from src.digital_ocean_utils import DigitalOceanClient
+from src.github import get_branches
 
-remove_branches = [
-    "524_AddPOPSNumber",
-    "528-Manager-Address-Approach",
-    "528-usairports-update-source",
-    "530-docker-compose-postgres-install-issue",
-    "532-update-moeo-socialservicesitelocations",
-    "534-q2-update-check-dataloading",
-    "535-Fix-Fooddrops",
-    "543-No-Build-On-Push",
-    "546-Metadata-Output",
-    "547-update-dcp-pops-version",
-    "549-QAQC-compare-to-all-records",
-    "553-Clarify-QAQC-Mapped",
-    "554-update-dot-data",
-    "558-remove-special-character-moeo-sonyc",
-    "559-update-projection-shapefile",
-    "560-doe-lcgms-latest",
-    "563-Update-TextileDrop",
-    "567_MOEOProgramName",
-    "574-Rename-POPS-Number",
-    "Address-Poetry-Merge-Conflict",
-    "dataloading-issue-template",
-]
+BUCKET_NAME = "edm-publishing"
+REPO_NAME = "db-facilities"
 
+def get_active_s3_folders():
+    all_branches = get_branches(repo=REPO_NAME, branches_blacklist=[])
+    all_folders = DigitalOceanClient(
+        bucket_name=BUCKET_NAME, repo_name=REPO_NAME,
+    ).get_all_folder_names_in_repo_folder()
 
-@st.cache_data
-def get_data(branch):
+    folders = sorted(list(set(all_folders).intersection(set(all_branches))))
+    return folders
+
+def get_latest_data(branch):
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-facilities/{branch}/latest/output"
     qc_diff = pd.read_csv(f"{url}/qc_diff.csv")
     qc_captype = pd.read_csv(f"{url}/qc_captype.csv")

--- a/src/facdb/helpers.py
+++ b/src/facdb/helpers.py
@@ -1,22 +1,6 @@
 import streamlit as st
 import pandas as pd
-from src.digital_ocean_utils import DigitalOceanClient
-from src.github import get_default_branch, get_branches
 
-BUCKET_NAME = "edm-publishing"
-REPO_NAME = "db-facilities"
-
-def get_active_s3_folders():
-    default_branch = get_default_branch(repo=REPO_NAME)
-    all_branches = get_branches(repo=REPO_NAME, branches_blacklist=[])
-    all_folders = DigitalOceanClient(
-        bucket_name=BUCKET_NAME, repo_name=REPO_NAME,
-    ).get_all_folder_names_in_repo_folder()
-
-    folders = sorted(list(set(all_folders).intersection(set(all_branches))))
-    folders.remove(default_branch)
-    folders = [default_branch] + folders
-    return folders
 
 def get_latest_data(branch):
     url = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-facilities/{branch}/latest/output"

--- a/src/github.py
+++ b/src/github.py
@@ -16,13 +16,20 @@ def parse_workflow(workflow):
         "url": workflow["html_url"],
     }
 
+
+def get_default_branch(repo:str):
+    url = f"https://api.github.com/repos/nycplanning/{repo}"
+    response = requests.get(url).json()
+    return response["default_branch"]
+
+
 def get_branches(repo:str, branches_blacklist:list):
-        url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
-        response = requests.get(url).json()
-        all_branches = [branch_info["name"] for branch_info in response]
-        return [
-            b for b in all_branches if b not in branches_blacklist
-        ]
+    url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
+    response = requests.get(url).json()
+    all_branches = [branch_info["name"] for branch_info in response]
+    return [
+        b for b in all_branches if b not in branches_blacklist
+    ]
 
 def get_workflow(repo, name):
     url = f"{BASE_URL}/{repo}/actions/workflows/{name}"

--- a/src/github.py
+++ b/src/github.py
@@ -3,7 +3,7 @@ import requests
 import streamlit as st
 
 ORG = "NYCPlanning"
-PERSONAL_TOKEN = os.environ["GHP_TOKEN"]
+PERSONAL_TOKEN = os.environ.get("GHP_TOKEN", None)
 headers = {"Authorization": "Bearer %s" % PERSONAL_TOKEN}
 BASE_URL = f"https://api.github.com/repos/{ORG}"
 
@@ -16,6 +16,13 @@ def parse_workflow(workflow):
         "url": workflow["html_url"],
     }
 
+def get_branches(repo:str, branches_blacklist:list):
+        url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
+        response = requests.get(url).json()
+        all_branches = [branch_info["name"] for branch_info in response]
+        return [
+            b for b in all_branches if b not in branches_blacklist
+        ]
 
 def get_workflow(repo, name):
     url = f"{BASE_URL}/{repo}/actions/workflows/{name}"

--- a/src/report_utils.py
+++ b/src/report_utils.py
@@ -1,0 +1,15 @@
+from src.digital_ocean_utils import DigitalOceanClient
+from src.github import get_default_branch, get_branches
+
+
+def get_active_s3_folders(repo:str, bucket_name:str):
+    default_branch = get_default_branch(repo=repo)
+    all_branches = get_branches(repo=repo, branches_blacklist=[])
+    all_folders = DigitalOceanClient(
+        bucket_name=bucket_name, repo_name=repo,
+    ).get_all_folder_names_in_repo_folder()
+
+    folders = sorted(list(set(all_folders).intersection(set(all_branches))))
+    folders.remove(default_branch)
+    folders = [default_branch] + folders
+    return folders

--- a/src/source_report_utils.py
+++ b/src/source_report_utils.py
@@ -34,7 +34,7 @@ def get_source_dataset_names(dataset: str, version: str) -> pd.DataFrame:
 def get_source_data_versions_from_build(dataset: str, version: str) -> pd.DataFrame:
     try:
         source_data_versions = pd.read_csv(
-            f"{construct_output_data_directory_url(dataset=dataset, version=version)}source_data_versions.csv",
+            f"{construct_output_data_directory_url(dataset=dataset, version=version)}/source_data_versions.csv",
             index_col=False,
             dtype=str,
         )

--- a/src/ztl/components/outputs_report.py
+++ b/src/ztl/components/outputs_report.py
@@ -40,21 +40,21 @@ def output_report():
     data_url = construct_output_data_directory_url(dataset=dataset, version="latest")
 
     bbldiff = pd.read_csv(
-        f"{data_url}qc_bbldiffs.csv",
+        f"{data_url}/qc_bbldiffs.csv",
         dtype=str,
         index_col=False,
     )
     bbldiff = bbldiff.fillna("NULL")
     qaqc_mismatch = pd.read_csv(
-        f"{data_url}qaqc_mismatch.csv",
+        f"{data_url}/qaqc_mismatch.csv",
         index_col=False,
     )
     qaqc_bbl = pd.read_csv(
-        f"{data_url}qaqc_bbl.csv",
+        f"{data_url}/qaqc_bbl.csv",
         index_col=False,
     )
     qaqc_null = pd.read_csv(
-        f"{data_url}qaqc_null.csv",
+        f"{data_url}/qaqc_null.csv",
         index_col=False,
     )
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -3,5 +3,5 @@ from src.github import get_branches
 TEST_REPO = "data-engineering-qaqc"
 
 def test_get_branches():
-    branches = get_branches(repo=TEST_REPO, branches_blacklist=[])
+    branches = get_branches(repo=TEST_REPO)
     assert "master" in branches

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,7 @@
+from src.github import get_branches
+
+TEST_REPO = "data-engineering-qaqc"
+
+def test_get_branches():
+    branches = get_branches(repo=TEST_REPO, branches_blacklist=[])
+    assert "master" in branches

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,12 @@
-from src.github import get_branches
+from src.github import get_default_branch, get_branches
 
 TEST_REPO = "data-engineering-qaqc"
 
+def test_get_default_branch():
+    branch = get_default_branch(repo=TEST_REPO)
+    assert branch == "master"
+
+
 def test_get_branches():
-    branches = get_branches(repo=TEST_REPO)
+    branches = get_branches(repo=TEST_REPO, branches_blacklist=[])
     assert "master" in branches


### PR DESCRIPTION
resolves #265 

## changes
- improve method of giving options for data to review for Dev DB QA
- use the same approach for FacDB
- improved lambda function formatting of directory URLs by not having a backslash at the end, making the use of the returned string more readable

## notes
- maintaining blacklists and/or whitelists to manually filter Digital Ocean folders and github branches is not ideal
- `get_active_s3_folders` approach for getting list of options for data to review :
  - get a list of all branches in the repo
  - get a list of all output folders in Digital Ocean
  - use the intersections of those two lists
  - put the default branch first in the dropdown selection
- thinking behind the above approach:
  - data is in Digital Ocean in folders named after the github branch which generated it
  - if a github branch doesn't exist anymore, the data it generated shouldn't be considered "active" and in need of review/useful in the QAQC app
    - otherwise, the dropdown selection would be as long as every branch we've ever used to run a build (for production, test, dev, ...)
- I manually archived many Digital Ocean folder into a folder called `ARCHIVED`

## screenshots
<img width="322" alt="image" src="https://github.com/NYCPlanning/data-engineering-qaqc/assets/7444289/75e0fd0b-2a9a-4748-98a6-eab99f70f16b">

<img width="322" alt="image" src="https://github.com/NYCPlanning/data-engineering-qaqc/assets/7444289/a58061ee-f0b6-408e-8993-72c39082ce50">
