### PR TITLE
Fvk gru expand source versions

### DIFF
--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -9,7 +9,7 @@ def source_table():
     cols = st.columns(column_widths)
     fields = ["Name", "Latest version archived by DE", "Date of archival"]
     for col, field_name in zip(cols, fields):
-        col.write(f"**{field_name}**", help="testing again")
+        col.write(f"**{field_name}**")
     source_versions = get_source_versions()
     for source in source_versions:
         col1, col2, col3 = st.columns(column_widths)

--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -5,16 +5,17 @@ from ..github import dispatch_workflow_button
 
 
 def source_table():
-    column_widths = (1, 2)
+    column_widths = (4, 5, 3)
     cols = st.columns(column_widths)
-    fields = ["Name", "Latest Version Archived by DE"]
+    fields = ["Name", "Latest version archived by DE", "Date of archival"]
     for col, field_name in zip(cols, fields):
-        col.write(f"**{field_name}**")
+        col.write(f"**{field_name}**", help="testing again")
     source_versions = get_source_versions()
     for source in source_versions:
-        col1, col2 = st.columns(column_widths)
+        col1, col2, col3 = st.columns(column_widths)
         col1.write(source)
-        col2.write(source_versions[source])
+        col2.write(source_versions[source]["version"])
+        col3.write(source_versions[source]["date"])
 
 
 def check_table(workflows):
@@ -52,7 +53,7 @@ def check_table(workflows):
                 )
             else:
                 st.info(format("No past run found"))
-        
+
         with run:
             dispatch_workflow_button(
                 "db-gru-qaqc",

--- a/src/gru/constants.py
+++ b/src/gru/constants.py
@@ -1,4 +1,4 @@
-import pandas as pd 
+import pandas as pd
 
 tests = pd.DataFrame(
     [

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -21,7 +21,8 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
     not_running_workflows = [
         action_name
         for action_name in tests["action_name"]
-        if action_name in workflows and workflows[action_name]["status"] not in ["queued", "in_progress"]
+        if action_name in workflows
+        and workflows[action_name]["status"] not in ["queued", "in_progress"]
     ]
     run_all_workflows(not_running_workflows)
     check_table(workflows)

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -22,7 +22,7 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
         action_name
         for action_name in tests["action_name"]
         if action_name in workflows
-        and workflows[action_name]["status"] not in ["queued", "in_progress"]
+        and (workflows[action_name]["status"] not in ["queued", "in_progress"])
     ]
     run_all_workflows(not_running_workflows)
     check_table(workflows)

--- a/src/gru/helpers.py
+++ b/src/gru/helpers.py
@@ -19,24 +19,31 @@ def get_source_version(dataset):
             aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
             endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
         )
-        folders = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter="/")["CommonPrefixes"]
-        folders = [ folder["Prefix"].split("/")[-2] for folder in folders if "latest" not in folder["Prefix"]]
+        folders = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter="/")[
+            "CommonPrefixes"
+        ]
+        folders = [
+            folder["Prefix"].split("/")[-2]
+            for folder in folders
+            if "latest" not in folder["Prefix"]
+        ]
         latest_version = max(folders)
-        timestamp = s3.list_objects(Bucket=bucket, Prefix=f"{prefix}{latest_version}/dcp_saf.zip")["Contents"][0]["LastModified"]
-        return { 
+        timestamp = s3.list_objects(
+            Bucket=bucket, Prefix=f"{prefix}{latest_version}/dcp_saf.zip"
+        )["Contents"][0]["LastModified"]
+        return {
             "version": latest_version.lower(),
-            "date": timestamp.strftime("%Y-%m-%d") 
+            "date": timestamp.strftime("%Y-%m-%d"),
         }
     else:
         config = get_datatset_config(dataset, "latest")
         if "execution_details" in config:
-            timestamp = datetime.strptime(config["execution_details"]["timestamp"], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%d")
+            timestamp = datetime.strptime(
+                config["execution_details"]["timestamp"], "%Y-%m-%d %H:%M:%S"
+            ).strftime("%Y-%m-%d")
         else:
             timestamp = ""
-        return { 
-            "version": config["dataset"]["version"],
-            "date": timestamp
-        }
+        return {"version": config["dataset"]["version"], "date": timestamp}
 
 
 @st.cache_data(ttl=120)
@@ -70,7 +77,7 @@ def render_status(workflow):
     )
     format = lambda status: f"{status}  \n[{timestamp}]({workflow['url']})"
     if workflow["status"] in ["queued", "in_progress"]:
-        st.warning(format(workflow["status"].capitalize().replace('_', ' ')))
+        st.warning(format(workflow["status"].capitalize().replace("_", " ")))
         st.spinner()
     elif workflow["status"] == "completed":
         if workflow["conclusion"] == "success":


### PR DESCRIPTION
Expands source versions table. Currently looks like this

![image](https://github.com/NYCPlanning/data-engineering-qaqc/assets/9454672/6ef67e2d-ee22-48f7-915c-56e9d052b61d)

for doitt buildin footprints date is fine, but saf should actually have a "23a"-like version. So I grab that now instead when the file was last modified. I also grab the timestamp of archival from `execution_details` (if present since its relatively new) and put that there for data library inputs. Now looks like this

![image](https://github.com/NYCPlanning/data-engineering-qaqc/assets/9454672/d369334b-e1c0-4747-bdfe-e33d2f7d8a56)
