### PR TITLE
Add edde page

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -7,14 +7,15 @@ SQL_FILE_DIRECTORY = Path().absolute() / ".data/sql"
 
 DATASET_PAGES = {
     "Home": "home",
-    "PLUTO": "pluto",
-    "Zoning Tax Lots": "ztl",
-    "Facilities DB": "facdb",
-    "Developments DB": "devdb",
-    #"Geosupport Demo": "geocode",
     "Capital Projects DB": "cpdb",
     "City Owned and Leased Properties": "colp",
+    "Developments DB": "devdb",
+    "Equitable Development Data Explorer": "edde",
+    "Facilities DB": "facdb",
+    "PLUTO": "pluto",
     "Template Repo DB": "trdb",
+    "Zoning Tax Lots": "ztl",
+    #"Geosupport Demo": "geocode",
     "GRU QAQC": "gru"
 }
 

--- a/src/digital_ocean_utils.py
+++ b/src/digital_ocean_utils.py
@@ -103,7 +103,9 @@ class DigitalOceanClient:
     def get_all_filenames_in_folder(self, folder_path: str):
         filenames = set()
         for object in self.bucket.objects.filter(Prefix=f"{folder_path}/"):
-            filenames.add(object.key.split("/")[-1])
+            filename = object.key.split("/")[-1]
+            if filename != "":
+                filenames.add(object.key.split("/")[-1])
         return filenames
 
     def unzip_csv(self, csv_filename, zipfile):

--- a/src/digital_ocean_utils.py
+++ b/src/digital_ocean_utils.py
@@ -90,11 +90,13 @@ class DigitalOceanClient:
             endpoint_url=os.getenv("AWS_S3_ENDPOINT"),
         )
 
-    def get_all_folder_names_in_repo_folder(self):
+    def get_all_folder_names_in_repo_folder(self, index=1):
         all_folders = set()
 
         for obj in self.repo:
-            all_folders.add(obj._key.split("/")[1])
+            folder = obj._key.split("/")[index]
+            if folder != "":
+                all_folders.add(folder)
 
         return all_folders
 

--- a/src/edde/components.py
+++ b/src/edde/components.py
@@ -1,0 +1,35 @@
+import streamlit as st
+from src.edde.helpers import compare_columns
+
+
+def column_comparison_table(old_data, new_data):
+    dropped, added, union, paired = compare_columns(old_data, new_data, True)
+    nrows_mismatch = max(len(dropped), len(added))
+
+    with st.expander(f"{len(union)} matching columns"):
+        for col in union:
+            st.info(col)
+
+    with st.expander(f"{len(paired)} columns with updated year in header"):
+        col1, col2 = st.columns(2)
+        col1.write("Old")
+        col2.write("Updated")
+
+        for old_column, matched_columns in paired:
+            with col1:
+                st.warning(old_column)
+            with col2:
+                st.warning(", ".join(matched_columns))
+
+    with st.expander(f"{len(dropped)} columns dropped, {len(added)} columns added"):
+        col1, col2 = st.columns(2)
+        col1.write("Dropped")
+        col2.write("Added")
+
+        for i in range(nrows_mismatch):
+            with col1:
+                if i < len(dropped):
+                    st.error(dropped[i])
+            with col2:
+                if i < len(added):
+                    st.success(added[i])

--- a/src/edde/edde.py
+++ b/src/edde/edde.py
@@ -32,7 +32,7 @@ def get_active_s3_folders(repo:str, bucket_name:str):
     folders = [default_branch] + folders
     return folders
 
-def facdb():
+def edde():
     st.title("EDDE QAQC")
 
     branches = get_active_s3_folders(repo="db-equitable-development-tool", bucket_name="edm-publishing")

--- a/src/edde/edde.py
+++ b/src/edde/edde.py
@@ -1,0 +1,67 @@
+import streamlit as st  # type: ignore
+import pandas as pd
+import numpy as np
+import requests
+from src.constants import COLOR_SCHEME
+from src.digital_ocean_utils import DigitalOceanClient
+from helpers import get_data
+
+def get_default_branch(repo:str):
+    url = f"https://api.github.com/repos/nycplanning/{repo}"
+    response = requests.get(url).json()
+    return response["default_branch"]
+
+
+def get_branches(repo:str, branches_blacklist:list):
+    url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
+    response = requests.get(url).json()
+    all_branches = [branch_info["name"] for branch_info in response]
+    return [
+        b for b in all_branches if b not in branches_blacklist
+    ]
+
+def get_active_s3_folders(repo:str, bucket_name:str):
+    default_branch = get_default_branch(repo=repo)
+    all_branches = get_branches(repo=repo, branches_blacklist=[])
+    all_folders = DigitalOceanClient(
+        bucket_name=bucket_name, repo_name=repo,
+    ).get_all_folder_names_in_repo_folder()
+
+    folders = sorted(list(set(all_folders).intersection(set(all_branches))))
+    folders.remove(default_branch)
+    folders = [default_branch] + folders
+    return folders
+
+def facdb():
+    st.title("EDDE QAQC")
+
+    branches = get_active_s3_folders(repo="db-equitable-development-tool", bucket_name="edm-publishing")
+    branch = st.sidebar.selectbox(
+        "Select a branch (will use latest)",
+        branches,
+        index=branches.index("main"),
+    )
+
+    branch_comp = st.sidebar.selectbox(
+        "select a branch for comparison",
+        branches,
+        index=branches.index("main"),
+    )
+
+    date_comp = st.sidebar.selectbox(
+        "select a branch for comparison",
+        [], ##todo - all other than latest if same branch, or latest if other branch
+    )
+    if st.sidebar.button(
+        label="Refresh data", help="Download newest files from Digital Ocean"
+    ):
+
+        st.cache_data.clear()
+        get_data(branch)
+
+    old_data = get_data(branch_comp, date_comp)
+    new_data = get_data(branch, "latest")
+
+    ## side bar - select by category? Or by geography?
+
+    ## Columns - dropped or added from last version

--- a/src/edde/edde.py
+++ b/src/edde/edde.py
@@ -1,55 +1,24 @@
-import streamlit as st  # type: ignore
-import pandas as pd
-import numpy as np
-import requests
+import streamlit as st
+
 from src.constants import COLOR_SCHEME
 from src.digital_ocean_utils import DigitalOceanClient
-from helpers import get_data, compare_columns
+from src.report_utils import get_active_s3_folders
+from src.edde.helpers import (
+    demographic_categories,
+    other_categories,
+    geographies,
+    get_demographics_data,
+    get_other_data,
+)
+from src.edde.components import column_comparison_table
 
-categories = [
-    "demographics",
-    "economics",
-    "housing_prodution",
-    "housing_security",
-    "quality_of_life"
-]
-
-geographies = [
-    "citywide",
-    "borough",
-    "puma"
-]
-
-def get_default_branch(repo:str):
-    url = f"https://api.github.com/repos/nycplanning/{repo}"
-    response = requests.get(url).json()
-    return response["default_branch"]
-
-
-def get_branches(repo:str, branches_blacklist:list):
-    url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
-    response = requests.get(url).json()
-    all_branches = [branch_info["name"] for branch_info in response]
-    return [
-        b for b in all_branches if b not in branches_blacklist
-    ]
-
-def get_active_s3_folders(repo:str, bucket_name:str):
-    default_branch = get_default_branch(repo=repo)
-    all_branches = get_branches(repo=repo, branches_blacklist=[])
-    all_folders = DigitalOceanClient(
-        bucket_name=bucket_name, repo_name=repo,
-    ).get_all_folder_names_in_repo_folder()
-
-    folders = sorted(list(set(all_folders).intersection(set(all_branches))))
-    folders.remove(default_branch)
-    folders = [default_branch] + folders
-    return folders
 
 def edde():
     st.title("EDDE QAQC")
 
-    branches = get_active_s3_folders(repo="db-equitable-development-tool", bucket_name="edm-publishing")
+    branches = get_active_s3_folders(
+        repo="db-equitable-development-tool", bucket_name="edm-publishing"
+    )
     branch = st.sidebar.selectbox(
         "Select a branch (will use latest)",
         branches,
@@ -57,51 +26,65 @@ def edde():
     )
 
     branch_comp = st.sidebar.selectbox(
-        "select a branch for comparison",
+        "Select a branch for comparison",
         branches,
         index=branches.index("main"),
     )
 
     date_comp = st.sidebar.selectbox(
-        "select a branch for comparison",
-        [], ##todo - all other than latest if same branch, or latest if other branch
-    )
-    if st.sidebar.button(
-        label="Refresh data", help="Download newest files from Digital Ocean"
-    ):
-
-        st.cache_data.clear()
-        get_data(branch)
-
-    old_data = get_data(branch_comp, date_comp)
-    new_data = get_data(branch, "latest")
-
-    try_pairing = st.sidebar.checkbox(
-        label="Try to match altered columns",
-        help="Some datasets have columns which remain effectively the same but update year in header.\nThis will try to identify those"
+        "Select an export for comparison",
+        DigitalOceanClient(
+            bucket_name="edm-publishing",
+            repo_name=f"db-eddt/{branch_comp}",
+        ).get_all_folder_names_in_repo_folder(
+            index=2
+        ),  ##todo - all other than latest if same branch, or latest if other branch
     )
 
-    for geography in geographies:
-        for category in category:
-            st.header(f"{category} - {geography}")
-            old = old_data[category][geography]
-            new = new_data[category][geography]
+    category_type = st.sidebar.selectbox(
+        "Select category type", ["Demographics", "Housing/Quality of Life"]
+    )
 
-            lost, added, union, paired = compare_columns(old, new, try_pairing)
-            nrows_mismatch = max(len(lost), len(added))
+    if category_type == "Demographics":
+        comparison_type = st.sidebar.selectbox(
+            "Comparison Type",
+            ["Between versions", "Between ACS years"],
+            help="Each build, exports are made for each ACS year. Comparisons can be made between same export files (ACS year) for different builds OR between different ACS years in the current build",
+        )
 
-            st.write(f"{len(union)} matching columns")
-            col1, col2 = st.columns(2)
-            col1.write("Lost")
-            col2.write("Added")
-            
-            for (old_column, matched_columns) in paired:
-                with col1: st.warning(old_column)
-                with col2: st.warning(", ".join(matched_columns))
+        old_data = get_demographics_data(branch_comp, date_comp)
+        new_data = get_demographics_data(branch, "latest")
 
-            for i in range(nrows_mismatch):
-                with col1: st.error(lost[i])
-                with col2: st.success(added[i])
+        for category in demographic_categories:
+            for geography in geographies:
+                old = old_data[category][geography]
+                new = new_data[category][geography]
+                keys = list(new.keys())
+                keys.sort(key=lambda x: x[-2:])
+                if comparison_type == "Between versions":
+                    for year in keys:
+                        st.header(f"{category}_{year}_{geography}.csv")
+                        if year in old:
+                            column_comparison_table(old[year], new[year])
+                        else:
+                            st.write("File not present in comparison build")
 
+                elif comparison_type == "Between ACS years":
+                    for i in range(len(keys) - 1):
+                        old_acs_year = keys[i]
+                        new_acs_year = keys[i + 1]
+                        st.header(f"{category} {geography}: {old_acs_year} vs {new_acs_year}")
+                        column_comparison_table(new[old_acs_year], new[new_acs_year])
+
+    elif category_type == "Housing/Quality of Life":
+        old_data = get_other_data(branch_comp, date_comp)
+        new_data = get_other_data(branch, "latest")
+
+        for category in other_categories:
+            for geography in geographies:
+                st.header(f"{category}_{geography}.csv")
+                old = old_data[category][geography]
+                new = new_data[category][geography]
+                column_comparison_table(old, new)
 
     ## Columns - dropped or added from last version

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -1,0 +1,4 @@
+
+
+def get_data(branch, version):
+    return None

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -10,16 +10,16 @@ def compare_header(left, right):
             return False
     return True
 
-# deswired output - columns in left not in right, columns in right not in left
+# desired output - columns in left not in right, columns in right not in left
 def compare_columns(left, right, try_pairing):
     lost = [ column for column in left.columns if column not in right.columns ]
     added = [ column for column in right.columns if column not in left.columns ]
     union = [ column for column in left.columns if column in right.columns ]
     if not try_pairing:
-        return lost, added, union
+        return lost, added, union, [] ## todo this is not the most elegant
     else:
         paired_columns = []
         for col in lost:
             matches = [ col2 for col2 in added if compare_header(col, col2) ]
             paired_columns.append(col, matches)
-        return lost, added, paired_columns
+        return lost, added, union, paired_columns

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -2,3 +2,24 @@
 
 def get_data(branch, version):
     return None
+
+## essentially, check if string are equal other than change of numeric characters
+def compare_header(left, right):
+    for char1, char2 in zip(left, right):
+        if char1 != char2 and not (is_digit(char1) and is_digit(char2)):
+            return False
+    return True
+
+# deswired output - columns in left not in right, columns in right not in left
+def compare_columns(left, right, try_pairing):
+    lost = [ column for column in left.columns if column not in right.columns ]
+    added = [ column for column in right.columns if column not in left.columns ]
+    union = [ column for column in left.columns if column in right.columns ]
+    if not try_pairing:
+        return lost, added, union
+    else:
+        paired_columns = []
+        for col in lost:
+            matches = [ col2 for col2 in added if compare_header(col, col2) ]
+            paired_columns.append(col, matches)
+        return lost, added, paired_columns

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -22,7 +22,7 @@ def get_demographics_data(branch: str, version: str):
     client = DigitalOceanClient("edm-publishing", "db-eddt")
     for category in demographic_categories:
         category_data = {}
-        files = client.get_all_filenames_in_folder(f"{branch}/{version}/{category}")
+        files = client.get_all_filenames_in_folder(f"db-eddt/{branch}/{version}/{category}")
         matches = [
             re.match(
                 "^(demographics|economics)_(\d{4})_(citywide|borough|puma).csv$", file

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -1,25 +1,95 @@
+import pandas as pd
+from itertools import groupby
+import re
+from src.digital_ocean_utils import DigitalOceanClient
+
+demographic_categories = ["demographics", "economics"]
+
+other_categories = [
+    "housing_production",
+    "housing_security",
+    "quality_of_life",
+]
+
+geographies = ["citywide", "borough", "puma"]
 
 
-def get_data(branch, version):
-    return None
+def get_demographics_data(branch: str, version: str):
+    parent_dir = (
+        f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-eddt/{branch}/{version}"
+    )
+    data = {}
+    client = DigitalOceanClient("edm-publishing", "db-eddt")
+    for category in demographic_categories:
+        category_data = {}
+        files = client.get_all_filenames_in_folder(f"{branch}/{version}/{category}")
+        matches = [
+            re.match(
+                "^(demographics|economics)_(\d{4})_(citywide|borough|puma).csv$", file
+            )
+            for file in files
+        ]
+        key = lambda m: (m.group(1), m.group(3))
+        for (category_match, geography), matches in groupby(
+            sorted(matches, key=key), key=key
+        ):
+            if category_match != category:
+                raise Exception(f'Unknown demographics category "{category_match}"')
+            category_data[geography] = {}
+            for match in matches:
+                year = match.group(2)
+                category_data[geography][year] = pd.read_csv(
+                    f"{parent_dir}/{category}/{category}_{year}_{geography}.csv"
+                )
+
+        data[category] = category_data
+
+    return data
+
+
+def get_other_data(branch: str, version: str):
+    parent_dir = (
+        f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-eddt/{branch}/{version}"
+    )
+    data = {}
+    for category in other_categories:
+        category_data = {}
+        for geography in geographies:
+            category_data[geography] = pd.read_csv(
+                f"{parent_dir}/{category}/{category}_{geography}.csv"
+            )
+        data[category] = category_data
+    return data
+
 
 ## essentially, check if string are equal other than change of numeric characters
-def compare_header(left, right):
+def compare_header(left: str, right: str):
+    if len(left) != len(right):
+        return False
     for char1, char2 in zip(left, right):
         if char1 != char2 and not (char1.isdigit() and char2.isdigit()):
             return False
     return True
 
+
 # desired output - columns in left not in right, columns in right not in left
-def compare_columns(left, right, try_pairing):
-    lost = [ column for column in left.columns if column not in right.columns ]
-    added = [ column for column in right.columns if column not in left.columns ]
-    union = [ column for column in left.columns if column in right.columns ]
+def compare_columns(left: pd.DataFrame, right: pd.DataFrame, try_pairing: bool):
+    dropped = [column for column in left.columns if column not in right.columns]
+    added = [column for column in right.columns if column not in left.columns]
+    union = [column for column in left.columns if column in right.columns]
     if not try_pairing:
-        return lost, added, union, [] ## todo this is not the most elegant
+        return dropped, added, union, []  ## todo this is not the most elegant
     else:
         paired_columns = []
-        for col in lost:
-            matches = [ col2 for col2 in added if compare_header(col, col2) ]
-            paired_columns.append(col, matches)
-        return lost, added, union, paired_columns
+        dropped_unpaired = []
+        added_paired = set()
+        for col in dropped:
+            matches = [col2 for col2 in added if compare_header(col, col2)]
+            if len(matches) > 0:
+                paired_columns.append((col, matches))
+                for match in matches:
+                    added_paired.add(match)
+            else:
+                dropped_unpaired.append(col)
+        added_unpaired = [col for col in added if col not in added_paired]
+        return dropped_unpaired, added_unpaired, union, paired_columns

--- a/src/edde/helpers.py
+++ b/src/edde/helpers.py
@@ -6,7 +6,7 @@ def get_data(branch, version):
 ## essentially, check if string are equal other than change of numeric characters
 def compare_header(left, right):
     for char1, char2 in zip(left, right):
-        if char1 != char2 and not (is_digit(char1) and is_digit(char2)):
+        if char1 != char2 and not (char1.isdigit() and char2.isdigit()):
             return False
     return True
 

--- a/src/gru/helpers.py
+++ b/src/gru/helpers.py
@@ -1,9 +1,9 @@
-import streamlit as st
-import pytz
 import time
 import os
 import boto3
 from datetime import datetime
+import streamlit as st
+
 from .constants import tests
 from src.digital_ocean_utils import get_datatset_config
 from src.github import get_workflow_runs, parse_workflow, dispatch_workflow
@@ -67,27 +67,6 @@ def get_qaqc_runs():
             if name not in workflows:
                 workflows[name] = parse_workflow(run)
     return workflows
-
-
-def render_status(workflow):
-    timestamp = (
-        datetime.fromisoformat(workflow["timestamp"])
-        .astimezone(pytz.timezone("US/Eastern"))
-        .strftime("%Y-%m-%d %H:%M")
-    )
-    format = lambda status: f"{status}  \n[{timestamp}]({workflow['url']})"
-    if workflow["status"] in ["queued", "in_progress"]:
-        st.warning(format(workflow["status"].capitalize().replace("_", " ")))
-        st.spinner()
-    elif workflow["status"] == "completed":
-        if workflow["conclusion"] == "success":
-            st.success(format("Success"))
-        elif workflow["conclusion"] == "cancelled":
-            st.info(format("Cancelled"))
-        elif workflow["conclusion"] == "failure":
-            st.error(format("Failed"))
-        else:
-            st.write(workflow["conclusion"])
 
 
 def after_workflow_dispatch():

--- a/src/report_utils.py
+++ b/src/report_utils.py
@@ -10,6 +10,6 @@ def get_active_s3_folders(repo:str, bucket_name:str):
     ).get_all_folder_names_in_repo_folder()
 
     folders = sorted(list(set(all_folders).intersection(set(all_branches))))
-    folders.remove(default_branch)
+    if default_branch in folders: folders.remove(default_branch)
     folders = [default_branch] + folders
     return folders

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -1,0 +1,7 @@
+from src.edde.helpers import compare_header
+
+def test_compare_header():
+    assert(compare_header("column1", "column1"))
+    assert(compare_header("column1", "column2"))
+    assert(not compare_header("column1", "other_column2"))
+    assert(not compare_header("column1", "bolumn1"))


### PR DESCRIPTION
For the sake of small PRs, figure this one can go now.

Adds a new page for EDDE, main functionality being to compare headers across versions since that was the biggest issue this build (next being entire columns being NA, will add that next). 

I think the code is relatively self-explanatory, but worth a build and local test (poke around and see what you think). Helper file is for data-specific stuff (doesn't touch streamlit), components are for actual logic for generating streamlit widgets.

Next steps:
- add checking of entirely NA columns, or comparing how much NA in each column from one version to next
- change format to something more tabular (categories as rows, columns by years, some sort of fun expand functionality) to allow for easier digesting and quick flagging of actual problems