### PR TITLE
Improve versions reporting

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ python-dotenv==0.*
 sqlalchemy==2.0.9
 streamlit-aggrid==0.*
 streamlit==1.*
+tabulate==0.9.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via streamlit
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   fiona
     #   pyproj
@@ -45,11 +45,11 @@ decorator==5.1.1
     # via validators
 entrypoints==0.4
     # via altair
-fiona==1.9.3
+fiona==1.9.4.post1
     # via geopandas
-fonttools==4.39.3
+fonttools==4.39.4
     # via matplotlib
-geopandas==0.12.2
+geopandas==0.13.0
     # via -r requirements.in
 gitdb==4.0.10
     # via gitpython
@@ -83,8 +83,6 @@ matplotlib==3.7.1
     # via -r requirements.in
 mdurl==0.1.2
     # via markdown-it-py
-munch==2.5.0
-    # via fiona
 numerize==0.12
     # via -r requirements.in
 numpy==1.24.3
@@ -124,7 +122,7 @@ protobuf==3.20.3
     # via streamlit
 psycopg2-binary==2.9.6
     # via -r requirements.in
-pyarrow==11.0.0
+pyarrow==12.0.0
     # via streamlit
 pydeck==0.8.0
     # via streamlit
@@ -154,47 +152,47 @@ python-dotenv==0.21.1
     # via -r requirements.in
 pytz==2023.3
     # via pandas
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
-requests==2.28.2
+requests==2.31.0
     # via streamlit
-rich==13.3.4
+rich==13.3.5
     # via streamlit
-s3transfer==0.6.0
+s3transfer==0.6.1
     # via boto3
 shapely==2.0.1
     # via geopandas
 six==1.16.0
     # via
-    #   munch
+    #   fiona
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
 sqlalchemy==2.0.9
     # via -r requirements.in
-streamlit==1.21.0
+streamlit==1.22.0
     # via
     #   -r requirements.in
     #   streamlit-aggrid
 streamlit-aggrid==0.3.4.post3
     # via -r requirements.in
+tabulate==0.9.0
+    # via -r requirements.in
 tenacity==8.2.2
-    # via plotly
+    # via
+    #   plotly
+    #   streamlit
 toml==0.10.2
     # via streamlit
 toolz==0.12.0
     # via altair
-tornado==6.3.1
+tornado==6.3.2
     # via streamlit
-typing-extensions==4.5.0
+typing-extensions==4.6.2
     # via
     #   sqlalchemy
     #   streamlit
-tzdata==2023.3
-    # via pytz-deprecation-shim
-tzlocal==4.3
+tzlocal==5.0.1
     # via streamlit
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   botocore
     #   requests

--- a/src/github.py
+++ b/src/github.py
@@ -8,7 +8,7 @@ headers = {"Authorization": "Bearer %s" % PERSONAL_TOKEN}
 BASE_URL = f"https://api.github.com/repos/{ORG}"
 
 
-def parse_workflow(workflow): ## json input
+def parse_workflow(workflow):  ## json input
     return {
         "status": workflow["status"],
         "conclusion": workflow["conclusion"],
@@ -16,24 +16,24 @@ def parse_workflow(workflow): ## json input
         "url": workflow["html_url"],
     }
 
-def workflow_is_running(workflow:dict):
+
+def workflow_is_running(workflow: dict):
     print(workflow)
     return workflow.get("status") in ["queued", "in_progress"]
 
 
-def get_default_branch(repo:str):
+def get_default_branch(repo: str):
     url = f"https://api.github.com/repos/nycplanning/{repo}"
     response = requests.get(url).json()
     return response["default_branch"]
 
 
-def get_branches(repo:str, branches_blacklist:list):
+def get_branches(repo: str, branches_blacklist: list):
     url = f"https://api.github.com/repos/nycplanning/{repo}/branches"
     response = requests.get(url).json()
     all_branches = [branch_info["name"] for branch_info in response]
-    return [
-        b for b in all_branches if b not in branches_blacklist
-    ]
+    return [b for b in all_branches if b not in branches_blacklist]
+
 
 def get_workflow(repo, name):
     url = f"{BASE_URL}/{repo}/actions/workflows/{name}"
@@ -51,7 +51,9 @@ def __get_workflow_runs_helper(url, params=None):
         )
 
 
-def get_workflow_runs(repo, workflow_name=None, items_per_page=100, total_items=100, page_start=0): ## 100 is to be max
+def get_workflow_runs(
+    repo, workflow_name=None, items_per_page=100, total_items=100, page_start=0
+):  ## 100 is to be max
     if workflow_name:
         url = f"{BASE_URL}/{repo}/actions/workflows/{workflow_name}/runs"
     else:
@@ -67,7 +69,7 @@ def get_workflow_runs(repo, workflow_name=None, items_per_page=100, total_items=
             url, params={"per_page": items_per_page, "page": page}
         )
         print(len(res))
-        workflows += res 
+        workflows += res
         if total_items is not None and len(workflows) < total_items:
             workflows = workflows[:total_items]
     print(len(workflows))

--- a/src/github.py
+++ b/src/github.py
@@ -73,11 +73,12 @@ def get_workflow_runs(repo, workflow_name=None, items_per_page=None, total_items
         return workflows
 
 
-def dispatch_workflow(repo, workflow_name, **inputs):
-    params = {"ref": "main", "inputs": inputs}
+def dispatch_workflow(repo, workflow_name, branch="main", **inputs):
+    params = {"ref": "fvk-2023-Q2-geosupport-version-as-arg", "inputs": inputs}
     url = f"{BASE_URL}/{repo}/actions/workflows/{workflow_name}/dispatches"
     response = requests.post(url, headers=headers, json=params)
     if response.status_code != 204:
+        print(response.content)
         raise Exception(
             f"Dispatch workflow failed with status code {response.status_code}"
         )

--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -77,7 +77,7 @@ def check_table(workflows, geosupport_version):
             [f"[{filename}]({folder}/{filename}.csv)" for filename in test["files"]]
         )
         outputs.write(files)
-        
+
         running = workflow_is_running(workflows.get(action_name, {}))
 
         with status:
@@ -95,5 +95,5 @@ def check_table(workflows, geosupport_version):
                 key=test["action_name"],
                 name=test["action_name"],
                 geosupport_version=get_geosupport_versions()[geosupport_version],
-                run_after=lambda: time.sleep(2)
+                run_after=lambda: time.sleep(2),
             )  ## refresh after 2 so that status has hopefully

--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -59,18 +59,13 @@ def check_table(workflows, geosupport_version):
 
         name.write(test["display_name"])
 
-        sources.write("  \n".join(test["sources"]))
+        folder = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-gru-qaqc/{geosupport_version}/{action_name}/latest"
 
-        folder = f"https://edm-publishing.nyc3.cdn.digitaloceanspaces.com/db-gru-qaqc/{geosupport_version}/{action_name}/latest"
-        files = "  \n".join(
-            [f"[{filename}]({folder}/{filename}.csv)" for filename in test["files"]]
-        )
-        outputs.write(files)
-        with outputs:
+        with sources:
             try:
                 versions = pd.read_csv(f"{folder}/versions.csv")
                 st.download_button(
-                    label="versions",
+                    label="\n".join(test["sources"]),
                     data=versions.to_csv(index=False).encode("utf-8"),
                     file_name="versions.csv",
                     mime="text/csv",
@@ -78,6 +73,11 @@ def check_table(workflows, geosupport_version):
                 )
             except:
                 pass
+
+        files = "  \n".join(
+            [f"[{filename}]({folder}/{filename}.csv)" for filename in test["files"]]
+        )
+        outputs.write(files)
         
         running = workflows.get(action_name, {}).get("status") in ["queued", "in_progress"]
 

--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import pytz
 import streamlit as st
+import pandas as pd
 
 from .constants import tests
 from .helpers import get_source_versions, after_workflow_dispatch
@@ -60,12 +61,20 @@ def check_table(workflows):
 
         sources.write("  \n".join(test["sources"]))
 
-        folder = f"https://edm-publishing.nyc3.digitaloceanspaces.com/db-gru-qaqc/{action_name}/latest"
+        folder = f"https://edm-publishing.nyc3.cdn.digitaloceanspaces.com/db-gru-qaqc/{action_name}/latest"
         files = "  \n".join(
-            [f"[{filename}.csv]({folder}/{filename}.csv)" for filename in test["files"]]
-            + [f"[versions.csv]({folder}/versions.csv)"]
+            [f"[{filename}]({folder}/{filename}.csv)" for filename in test["files"]]
         )
         outputs.write(files)
+        with outputs:
+            versions = pd.read_csv(f"{folder}/versions.csv")
+            st.download_button(
+                label="versions",
+                data=versions.to_csv(index=False).encode("utf-8"),
+                file_name="versions.csv",
+                mime="text/csv",
+                help=versions.to_markdown(index=False),
+            )
 
         with status:
             if action_name in workflows:

--- a/src/gru/components.py
+++ b/src/gru/components.py
@@ -43,7 +43,7 @@ def source_table():
         col3.write(source_versions[source]["date"])
 
 
-def check_table(workflows):
+def check_table(workflows, geosupport_version:str='latest'):
     column_widths = (3, 3, 4, 3, 2)
     cols = st.columns(column_widths)
     fields = ["Name", "Sources", "Latest results", "Status", "Run Check"]
@@ -75,12 +75,13 @@ def check_table(workflows):
                 mime="text/csv",
                 help=versions.to_markdown(index=False),
             )
+        
+        running = workflows.get(action_name, {}).get("status") in ["queued", "in_progress"]
 
         with status:
             if action_name in workflows:
                 workflow = workflows[action_name]
                 status_details(workflow)
-                running = workflow["status"] in ["queued", "in_progress"]
                 st.session_state["currently_running"] = (
                     st.session_state["currently_running"] or running
                 )
@@ -94,5 +95,6 @@ def check_table(workflows):
                 disabled=running,
                 key=test["action_name"],
                 name=test["action_name"],
-                run_after=after_workflow_dispatch,
+                geosupport_version=geosupport_version,
+                run_after=after_workflow_dispatch
             )  ## refresh after 2 so that status has hopefully

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -4,6 +4,7 @@ def gru():
     from .constants import readme_markdown_text, tests
     from .helpers import get_qaqc_runs, run_all_workflows, get_geosupport_versions
     from .components import source_table, check_table
+    from src.github import workflow_is_running
 
     st.markdown("<style>button{text-align:left; margin:0}.stDownloadButton{max-width:195px;}</style>", unsafe_allow_html=True)
 
@@ -38,6 +39,6 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
     st.markdown(readme_markdown_text)
 
     # this state gets set when an action is triggered, set to false once it's complete
-    while st.session_state["currently_running"]:
+    while any([workflow_is_running(workflow) for workflow in workflows.values()]):
         time.sleep(5)
         st.experimental_rerun()

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -5,7 +5,7 @@ def gru():
     from .helpers import get_qaqc_runs, run_all_workflows, get_geosupport_versions
     from .components import source_table, check_table
 
-    st.markdown("<style>.stDownloadButton{text-align:left; max-width:200px}</style>", unsafe_allow_html=True)
+    st.markdown("<style>button{text-align:left; margin:0}.stDownloadButton{max-width:195px;}</style>", unsafe_allow_html=True)
 
     geosupport_version= st.sidebar.selectbox(
         label="Choose a Geosupport version",

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -31,8 +31,8 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
         if action_name not in workflows
         or (workflows[action_name]["status"] not in ["queued", "in_progress"])
     ]
-    run_all_workflows(not_running_workflows, geosupport_version_to_run)
-    check_table(workflows, geosupport_version=geosupport_version_to_run)
+    run_all_workflows(not_running_workflows, geosupport_version)
+    check_table(workflows, geosupport_version=geosupport_version)
 
     st.header("README")
     st.markdown(readme_markdown_text)

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -5,12 +5,12 @@ def gru():
     from .helpers import get_qaqc_runs, run_all_workflows, get_geosupport_versions
     from .components import source_table, check_table
 
-    geosupport_versions = get_geosupport_versions()
+    st.markdown("<style>.stDownloadButton{text-align:left; max-width:200px}</style>", unsafe_allow_html=True)
+
     geosupport_version= st.sidebar.selectbox(
         label="Choose a Geosupport version",
-        options=list(geosupport_versions.keys())
+        options=list(get_geosupport_versions().keys())
     )
-    geosupport_version_to_run = geosupport_versions[geosupport_version]
 
     st.header("GRU QAQC")
     st.write(

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -6,11 +6,14 @@ def gru():
     from .components import source_table, check_table
     from src.github import workflow_is_running
 
-    st.markdown("<style>button{text-align:left; margin:0}.stDownloadButton{max-width:195px;}</style>", unsafe_allow_html=True)
+    st.markdown(
+        "<style>button{text-align:left; margin:0}.stDownloadButton{max-width:195px;}</style>",
+        unsafe_allow_html=True,
+    )
 
-    geosupport_version= st.sidebar.selectbox(
+    geosupport_version = st.sidebar.selectbox(
         label="Choose a Geosupport version",
-        options=list(get_geosupport_versions().keys())
+        options=list(get_geosupport_versions().keys()),
     )
 
     st.header("GRU QAQC")

--- a/src/gru/gru.py
+++ b/src/gru/gru.py
@@ -2,8 +2,15 @@ def gru():
     import streamlit as st
     import time
     from .constants import readme_markdown_text, tests
-    from .helpers import get_qaqc_runs, run_all_workflows
+    from .helpers import get_qaqc_runs, run_all_workflows, get_geosupport_versions
     from .components import source_table, check_table
+
+    geosupport_versions = get_geosupport_versions()
+    geosupport_version= st.sidebar.selectbox(
+        label="Choose a Geosupport version",
+        options=list(geosupport_versions.keys())
+    )
+    geosupport_version_to_run = geosupport_versions[geosupport_version]
 
     st.header("GRU QAQC")
     st.write(
@@ -17,15 +24,15 @@ Github repo found [here](https://github.com/NYCPlanning/db-gru-qaqc/)."""
     source_table()
 
     st.header("QAQC Checks")
-    workflows = get_qaqc_runs()
+    workflows = get_qaqc_runs(geosupport_version)
     not_running_workflows = [
         action_name
         for action_name in tests["action_name"]
-        if action_name in workflows
-        and (workflows[action_name]["status"] not in ["queued", "in_progress"])
+        if action_name not in workflows
+        or (workflows[action_name]["status"] not in ["queued", "in_progress"])
     ]
-    run_all_workflows(not_running_workflows)
-    check_table(workflows)
+    run_all_workflows(not_running_workflows, geosupport_version_to_run)
+    check_table(workflows, geosupport_version=geosupport_version_to_run)
 
     st.header("README")
     st.markdown(readme_markdown_text)

--- a/src/gru/helpers.py
+++ b/src/gru/helpers.py
@@ -82,7 +82,7 @@ def after_workflow_dispatch():
 def run_all_workflows(actions, geosupport_version):
     def on_click():
         for action in actions:
-            dispatch_workflow("db-gru-qaqc", "main.yml", name=action, geosupport_version=geosupport_version)
+            dispatch_workflow("db-gru-qaqc", "main.yml", name=action, geosupport_version=get_geosupport_versions()[geosupport_version])
         after_workflow_dispatch()
 
     return st.button("Run all", key="all", on_click=on_click)

--- a/src/gru/helpers.py
+++ b/src/gru/helpers.py
@@ -3,6 +3,8 @@ import os
 import boto3
 from datetime import datetime
 import streamlit as st
+import requests
+import re
 
 from .constants import tests
 from src.digital_ocean_utils import get_datatset_config
@@ -54,17 +56,20 @@ def get_source_versions():
     return versions
 
 
-def get_qaqc_runs():
+def map_geosupport_version(patched_version):
+    major, minor, _ = patched_version.split(".")
+    return f"{major}{chr(int(minor)+96)}" ## converts 1 to 'a', 2 to 'b', etc
+
+
+def get_qaqc_runs(geosupport_version):
     workflows = {}
     for run in get_workflow_runs("db-gru-qaqc", "main.yml"):
         if len(workflows) == 7:
             break
-        if "[" in run["display_title"]:  ## runs triggered by issues
-            name = run["display_title"].split("[", 1)[1].split("]")[0]
-        else:  ## runs triggered by this app
-            name = run["name"]
-        if name in tests["action_name"].values:
-            if name not in workflows:
+        match = re.match("^(\d+\.\d+\.\d+)\_(.+)$", run["name"])
+        if match:
+            gs_version, name = map_geosupport_version(match.group(1)), match.group(2)
+            if name in tests["action_name"].values and (gs_version == geosupport_version) and (name not in workflows):
                 workflows[name] = parse_workflow(run)
     return workflows
 
@@ -74,10 +79,23 @@ def after_workflow_dispatch():
     time.sleep(2)
 
 
-def run_all_workflows(actions):
+def run_all_workflows(actions, geosupport_version):
     def on_click():
         for action in actions:
-            dispatch_workflow("db-gru-qaqc", "main.yml", name=action)
+            dispatch_workflow("db-gru-qaqc", "main.yml", name=action, geosupport_version=geosupport_version)
         after_workflow_dispatch()
 
     return st.button("Run all", key="all", on_click=on_click)
+
+
+@st.cache_data(ttl=600)
+def get_geosupport_versions():
+   images = requests.get("https://hub.docker.com/v2/repositories/nycplanning/docker-geosupport/tags?page_size=1000").json()["results"]
+   images_by_code = {}
+   for image in images:
+       if re.match("^\d+\.\d+\.\d+$", image["name"]):
+           major, minor, _ = image["name"].split(".")
+           code = f"{major}{chr(int(minor)+96)}"
+           if code not in images_by_code:
+               images_by_code[code] = image["name"]
+   return images_by_code


### PR DESCRIPTION
Seems clunky to download each versions file, so I replaced the link with a button that displays versions on hover

<img width="1336" alt="image" src="https://github.com/NYCPlanning/data-engineering-qaqc/assets/9454672/08747a85-4291-47ee-944f-ce14466cac35">

A little clunky now maybe to have links for the outputs and button for versions? But streamlit doesn't have a great way to have hover for text. I would make all download buttons, but then they all need to be read into memory. Not that they're that large, more just each of the web calls will take time for startup and that seems not quite ideal.

This is going to be a draft for a moment, I want to look into specifying version of geocode as an arg to the workflows